### PR TITLE
Add Support for Merging Data with Iceberg

### DIFF
--- a/lambdas/serverless_processing_iceberg/Dockerfile
+++ b/lambdas/serverless_processing_iceberg/Dockerfile
@@ -1,0 +1,23 @@
+# Use a imagem base do AWS Lambda para Python 3.10
+FROM public.ecr.aws/lambda/python:3.10
+
+# Instalar Git (necessário para instalar pacotes do GitHub)
+RUN yum update -y && yum install -y git
+
+# Copiar o requirements.txt
+COPY requirements.txt .
+
+# Instalar todos os pacotes normalmente (sem --no-deps)
+RUN pip install -r requirements.txt
+
+# Instalar o PyIceberg do Git
+RUN pip install --no-deps "git+https://github.com/apache/iceberg-python.git#egg=pyiceberg"
+
+# Resolver todas as dependências do PyIceberg
+RUN pip install --no-cache-dir "pyiceberg[pyarrow,s3fs,hive,glue]"
+
+# Copiar o código da Lambda
+COPY main.py .
+
+# Definir o handler da Lambda
+CMD [ "main.handler" ]

--- a/lambdas/serverless_processing_iceberg/main.py
+++ b/lambdas/serverless_processing_iceberg/main.py
@@ -1,0 +1,121 @@
+import polars as pl
+import boto3
+import re
+import duckdb
+import os
+import yaml
+
+from pyiceberg.catalog import load_catalog
+
+LAYER_SILVER = "silver"
+LAYER_ARTIFACTS = "artifacts"
+YAML_FILE_KEY = "yaml/tables.yaml"
+STORAGE_OPTIONS = {
+    "AWS_S3_ALLOW_UNSAFE_RENAME": "True",
+}
+s3_client = boto3.client("s3")
+
+catalog = load_catalog("glue", **{"type": "glue"})
+
+
+def get_primary_keys(table_name, tenant):
+
+    # Baixar o arquivo YAML do S3
+    yaml_file = s3_client.get_object(
+        Bucket=f"{tenant}-{LAYER_ARTIFACTS}",
+        Key=f"{tenant}/{YAML_FILE_KEY}",
+    )
+    yaml_content = yaml_file["Body"].read().decode("utf-8")
+
+    # Carregar o conteúdo do YAML
+    data = yaml.safe_load(yaml_content)
+
+    # Achar as primary keys da tabela especificada
+    for table in data["tenants"][0]["tables"]:
+        if table["table_name"] == table_name:
+            return list(table.get("primary_keys"))
+
+
+def check_s3_partition_is_empty(bucket_name, partition_prefix):
+    # Tenta listar objetos que começam com o prefixo fornecido
+    response = s3_client.list_objects_v2(
+        Bucket=bucket_name, Prefix=partition_prefix, MaxKeys=1
+    )
+
+    # Se houver ao menos um objeto, o prefixo existe
+    if "Contents" in response:
+        return False
+    else:
+        return True
+
+def configure_duckdb():
+    con = duckdb.connect(database=":memory:")
+    home_directory = "/tmp/duckdb/"
+    if not os.path.exists(home_directory):
+        os.mkdir(home_directory)
+    con.execute(f"SET home_directory='{home_directory}';INSTALL httpfs;LOAD httpfs;")
+    con.execute("INSTALL aws;LOAD aws;")
+    con.execute(
+        """CREATE SECRET (
+        TYPE S3,
+        PROVIDER CREDENTIAL_CHAIN
+    );"""
+    )
+    return con
+
+
+def filter_df(df_source: pl.DataFrame, primary_keys, order_date_col="insert_date"):
+    ranked_df = df_source.with_columns(
+        pl.col(order_date_col).rank("ordinal").over(primary_keys).alias("rank")
+    )
+
+    # Filtrando para obter apenas os registros com rank igual a 1
+    df_filtered = ranked_df.filter(pl.col("rank") == 1).drop(["rank", "insert_date"])
+
+    return df_filtered
+
+
+def process_data(bucket: str, s3_object: str):
+
+    s3_path = f"s3://{bucket}/{s3_object}"
+    tenant = bucket.split("-")[0]
+    table_name = re.search(r"firehose-data/([^/]+)/", s3_object).group(1)
+    primary_keys = get_primary_keys(table_name, tenant)
+
+    con = configure_duckdb()
+    pyarrow_data_frame = con.query(f"SELECT * FROM read_json_auto('{s3_path}');").pl()
+    s3_destination = f"s3://{tenant}-{LAYER_SILVER}/{table_name}"
+
+    full_table_name = f"{tenant}.{table_name}"
+    #TODO: talvez trocar aqui por algo que  cheque no catalog
+    if not any(tenant == item[0] for item in catalog.list_namespaces()):
+        catalog.create_namespace(tenant)
+    if not any(tenant == item[0] for item in catalog.list_tables(tenant)):
+        arrow_data_frame = pyarrow_data_frame.drop("insert_date").to_arrow().schema
+        table = catalog.create_table(
+            identifier=full_table_name,
+            location=s3_destination,
+            schema=arrow_data_frame)
+    else:
+        arrow_data_frame = pyarrow_data_frame.drop("insert_date").to_arrow().schema
+        table = catalog.load_table(full_table_name)
+        with table.update_schema() as update_schema:
+            update_schema.union_by_name(arrow_data_frame)
+
+    if primary_keys:
+        filtered_data_frame = filter_df(pyarrow_data_frame, primary_keys)
+        table.upsert(filtered_data_frame.to_arrow(), primary_keys)
+        return "Data Writed"
+
+    table.append(arrow_data_frame)
+
+    return "Data Writed"
+
+
+def handler(event, context):
+
+    s3_event = event["Records"][0]["s3"]
+    bucket = s3_event["bucket"]["name"]
+    s3_object = s3_event["object"]["key"]
+
+    return process_data(bucket, s3_object)

--- a/lambdas/serverless_processing_iceberg/requirements.txt
+++ b/lambdas/serverless_processing_iceberg/requirements.txt
@@ -1,0 +1,9 @@
+# Dependências principais
+polars==1.7.1
+pyarrow==17.0.0
+s3fs==2024.9.0
+boto3==1.35.14
+duckdb==1.0.0
+httpfs==0.0.1
+pyyaml==6.0.2
+sqlalchemy

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pydantic==2.9.0
 pydantic_core==2.23.2
 mangum==0.17.0
 pyyaml==6.0.2
+git+https://github.com/apache/iceberg-python.git#egg=pyiceberg[pyarrow,s3fs,glue]

--- a/stack/serverless_data_lake_stack.py
+++ b/stack/serverless_data_lake_stack.py
@@ -125,7 +125,7 @@ class ServerlessDataLakeStack(Stack):
             self.create_jobs(lambdas["serverless_analytics"], jobs)
 
         self.add_s3_event_notification(
-            lambdas["serverless_processing_iceberg"], buckets["Bronze"]
+            lambdas["serverless_processing"], buckets["Bronze"]
         )
         self.deploy_yaml_to_s3(buckets["Artifacts"], tenant)
 


### PR DESCRIPTION
Context
Our current serverless architecture processes data in Delta Lake, handling upserts with MERGE, and later converts it to Iceberg using Apache XTable for better AWS service integration.

Motivation
This update introduces the option to perform MERGE operations directly in Iceberg, allowing users to maintain a Lakehouse purely with Iceberg if desired. By default, the system still processes data in Delta and converts it to Iceberg using XTable, ensuring backward compatibility.

Main Changes
Added support for MERGE in Iceberg using PyIceberg.
Introduced a configuration option to use Iceberg natively instead of Delta.
Default behavior remains Delta → Iceberg conversion via XTable.

Impact
Users can choose between Delta + XTable conversion or a pure Iceberg Lakehouse.
Maintains full compatibility with existing workflows.