### PR TITLE
Add automatic ACM certificate creation for custom domains

### DIFF
--- a/stack/serverless_data_lake_stack.py
+++ b/stack/serverless_data_lake_stack.py
@@ -189,7 +189,7 @@ class ServerlessDataLakeStack(Stack):
                 jobs=table_data.get("jobs"),
             )
 
-        # Deploy frontend (S3 + CloudFront) with custom domain tadpole.com
+        # Deploy frontend (S3 + CloudFront) with custom domain tadpoledata.com
         # The ACM certificate is created automatically with DNS validation via Route53.
         # Note: Stack must be deployed in us-east-1 for CloudFront custom domains.
         self.website = StaticWebsite(
@@ -199,8 +199,8 @@ class ServerlessDataLakeStack(Stack):
             source_path="frontend/dist",
             api_endpoint=self.api_gateway.endpoint,
             custom_domain=CustomDomainConfig(
-                domain_name="tadpole.com",
-                hosted_zone_name="tadpole.com",
+                domain_name="tadpoledata.com",
+                hosted_zone_name="tadpoledata.com",
             ),
         )
 

--- a/stack/serverless_data_lake_stack.py
+++ b/stack/serverless_data_lake_stack.py
@@ -189,23 +189,19 @@ class ServerlessDataLakeStack(Stack):
                 jobs=table_data.get("jobs"),
             )
 
-        # Deploy frontend (S3 + CloudFront)
-        certificate_arn = self.node.try_get_context("certificate_arn")
-        custom_domain = None
-        if certificate_arn:
-            custom_domain = CustomDomainConfig(
-                domain_name="tadpole.com",
-                certificate_arn=certificate_arn,
-                hosted_zone_name="tadpole.com",
-            )
-
+        # Deploy frontend (S3 + CloudFront) with custom domain tadpole.com
+        # The ACM certificate is created automatically with DNS validation via Route53.
+        # Note: Stack must be deployed in us-east-1 for CloudFront custom domains.
         self.website = StaticWebsite(
             self,
             "Frontend",
             site_name="data-lake",
             source_path="frontend/dist",
             api_endpoint=self.api_gateway.endpoint,
-            custom_domain=custom_domain,
+            custom_domain=CustomDomainConfig(
+                domain_name="tadpole.com",
+                hosted_zone_name="tadpole.com",
+            ),
         )
 
         # Output API endpoint

--- a/stack/serverless_data_lake_stack.py
+++ b/stack/serverless_data_lake_stack.py
@@ -39,7 +39,7 @@ from aws_cdk.aws_lambda_python_alpha import PythonLayerVersion
 from constructs import Construct
 from typing import List, Optional, Dict, Any
 
-from .constructs import ApiGateway, ApiService, ApiServiceConfig
+from .constructs import ApiGateway, ApiService, ApiServiceConfig, StaticWebsite
 
 TIMEZONE = "America/Sao_Paulo"
 ARTIFACTS_FOLDER = "artifacts"
@@ -187,6 +187,15 @@ class ServerlessDataLakeStack(Stack):
                 tables=table_data.get("tables", []),
                 jobs=table_data.get("jobs"),
             )
+
+        # Deploy frontend (S3 + CloudFront)
+        self.website = StaticWebsite(
+            self,
+            "Frontend",
+            site_name="data-lake",
+            source_path="frontend/dist",
+            api_endpoint=self.api_gateway.endpoint,
+        )
 
         # Output API endpoint
         CfnOutput(

--- a/stack/serverless_data_lake_stack.py
+++ b/stack/serverless_data_lake_stack.py
@@ -40,6 +40,7 @@ from constructs import Construct
 from typing import List, Optional, Dict, Any
 
 from .constructs import ApiGateway, ApiService, ApiServiceConfig, StaticWebsite
+from .constructs.static_website import CustomDomainConfig
 
 TIMEZONE = "America/Sao_Paulo"
 ARTIFACTS_FOLDER = "artifacts"
@@ -189,12 +190,22 @@ class ServerlessDataLakeStack(Stack):
             )
 
         # Deploy frontend (S3 + CloudFront)
+        certificate_arn = self.node.try_get_context("certificate_arn")
+        custom_domain = None
+        if certificate_arn:
+            custom_domain = CustomDomainConfig(
+                domain_name="tadpole.com",
+                certificate_arn=certificate_arn,
+                hosted_zone_name="tadpole.com",
+            )
+
         self.website = StaticWebsite(
             self,
             "Frontend",
             site_name="data-lake",
             source_path="frontend/dist",
             api_endpoint=self.api_gateway.endpoint,
+            custom_domain=custom_domain,
         )
 
         # Output API endpoint


### PR DESCRIPTION
## Summary
Enhanced the static website construct to automatically create and validate ACM certificates for custom domains, eliminating the need to manually provision certificates beforehand. The certificate is created with DNS validation via Route53 for a seamless deployment experience.

## Key Changes

- **Automatic Certificate Management**: Modified `CustomDomainConfig` to make `certificate_arn` optional. When not provided, a new ACM certificate is automatically created with DNS validation.
  
- **Improved Domain Configuration**: 
  - Made `hosted_zone_name` a required field (more intuitive than requiring zone ID)
  - Made `hosted_zone_id` optional for flexibility
  - Updated field descriptions with practical examples

- **Refactored Certificate Resolution**: Extracted certificate logic into `_resolve_certificate()` method that handles both existing certificates and automatic creation scenarios.

- **Enhanced Hosted Zone Lookup**: Extracted zone lookup logic into `_lookup_hosted_zone()` method to support both ID-based and name-based lookups.

- **Fixed DNS Record Creation**: Improved `_create_dns_record()` to correctly handle both apex domains (e.g., `tadpole.com`) and subdomains (e.g., `app.tadpole.com`).

- **Updated Documentation**: 
  - Added note about us-east-1 requirement for CloudFront certificates
  - Provided practical usage examples with and without custom domains
  - Updated docstrings to reflect new automatic certificate behavior

- **Integrated Frontend Deployment**: Added frontend deployment to the main stack with custom domain configuration pointing to `tadpoledata.com`.

## Implementation Details

The certificate creation uses `acm.CertificateValidation.from_dns()` which automatically creates the required Route53 DNS validation records, enabling fully automated certificate provisioning without manual intervention.

The hosted zone lookup is now cached in `self._hosted_zone` to avoid redundant lookups and to ensure the same zone is used for both certificate validation and DNS record creation.

https://claude.ai/code/session_01XVuN6CA3Cfm5xLXHKsVnju