### PR TITLE
Add Bronze layer support with direct S3 JSON querying

### DIFF
--- a/lambdas/query_api/main.py
+++ b/lambdas/query_api/main.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 AWS_ACCOUNT_ID = os.environ.get("AWS_ACCOUNT_ID")
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
 CATALOG_NAME = os.environ.get("CATALOG_NAME", "tadpole")
+BRONZE_BUCKET = os.environ.get("BRONZE_BUCKET", "")
 
 app = FastAPI()
 
@@ -81,18 +82,38 @@ def configure_duckdb():
         raise
 
 
+def _bronze_replacer(match: re.Match) -> str:
+    """Replace domain.bronze.table with read_json_auto on the bronze S3 path."""
+    domain = match.group(1)
+    table = match.group(2)
+    return (
+        f"read_json_auto('s3://{BRONZE_BUCKET}/firehose-data/{domain}/{table}/**',"
+        f" union_by_name=true, format='newline_delimited')"
+    )
+
+
 def rewrite_query(sql: str, catalog_name: str = "") -> str:
     """Rewrite user-friendly table references to DuckDB/Glue format.
 
-    Transforms: domain.layer.table  →  catalog.domain_layer.table
-    Example:    sales.silver.teste  →  tadpole.sales_silver.teste
+    Transforms:
+      domain.silver.table  →  catalog.domain_silver.table
+      domain.gold.table    →  catalog.domain_gold.table
+      domain.bronze.table  →  read_json_auto('s3://bucket/firehose-data/domain/table/**')
     """
     catalog = catalog_name or CATALOG_NAME
-    return re.sub(
+    # Bronze: read JSONL directly from S3
+    sql = re.sub(
+        r'\b(\w+)\.bronze\.(\w+)\b',
+        _bronze_replacer,
+        sql,
+    )
+    # Silver/Gold: Glue Iceberg catalog
+    sql = re.sub(
         r'\b(\w+)\.(silver|gold)\.(\w+)\b',
         rf'{catalog}.\1_\2.\3',
         sql,
     )
+    return sql
 
 
 @app.get("/consumption/query")

--- a/lambdas/query_api/main.py
+++ b/lambdas/query_api/main.py
@@ -88,7 +88,7 @@ def _bronze_replacer(match: re.Match) -> str:
     table = match.group(2)
     return (
         f"read_json_auto('s3://{BRONZE_BUCKET}/firehose-data/{domain}/{table}/**',"
-        f" union_by_name=true, format='newline_delimited')"
+        f" union_by_name=true, format='auto')"
     )
 
 

--- a/stack/serverless_data_lake_stack.py
+++ b/stack/serverless_data_lake_stack.py
@@ -264,6 +264,7 @@ class ServerlessDataLakeStack(Stack):
             elif service_name == "query_api":
                 env_overrides["AWS_ACCOUNT_ID"] = self.account
                 env_overrides["SCHEMA_BUCKET"] = buckets["Artifacts"].bucket_name
+                env_overrides["BRONZE_BUCKET"] = buckets["Bronze"].bucket_name
             elif service_name == "transform_jobs":
                 env_overrides["SCHEMA_BUCKET"] = buckets["Artifacts"].bucket_name
                 env_overrides["TENANT"] = tenant


### PR DESCRIPTION
## Summary
This PR adds support for querying the Bronze layer directly from S3 by reading JSONL files, complementing the existing Silver and Gold layer queries that use the Glue Iceberg catalog.

## Key Changes
- **Query rewriting logic**: Extended `rewrite_query()` to handle three table reference patterns:
  - `domain.bronze.table` → `read_json_auto('s3://bucket/firehose-data/domain/table/**')`
  - `domain.silver.table` → `catalog.domain_silver.table` (existing Glue catalog)
  - `domain.gold.table` → `catalog.domain_gold.table` (existing Glue catalog)

- **New helper function**: Added `_bronze_replacer()` to construct S3 paths for Bronze layer queries with DuckDB's `read_json_auto()` function, enabling schema inference and union-by-name semantics

- **Environment configuration**: Added `BRONZE_BUCKET` environment variable to the query_api Lambda function, populated from the Bronze S3 bucket created in the CDK stack

## Implementation Details
- Bronze queries use `read_json_auto()` with `union_by_name=true` to handle schema evolution across partitioned JSONL files
- The regex pattern matching is ordered (Bronze first, then Silver/Gold) to prevent conflicts
- Bronze bucket path follows the convention: `s3://bucket/firehose-data/{domain}/{table}/**`

https://claude.ai/code/session_01TDQVbJeTAjU2b3UnRRq8ZH