### PR TITLE
docs: Add comprehensive API reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,236 @@ $ cdk deploy
 * **Storage**: Delta-rs is used for data merging and schema evolution, ensuring that data remains up-to-date in the silver and gold layers.
 * **Transformation**: EventBridge triggers final transformations, storing the refined data in the gold layer for consumption.
 * **Consumer API**: Then a API is build, so we can consume this data
+
+## API Reference
+
+All APIs are served through a single API Gateway and use FastAPI with Mangum for Lambda integration. CORS is enabled on all endpoints.
+
+### 1. Endpoints API (`/endpoints`) — Schema Registry
+
+Manages ingestion endpoint schemas. When an endpoint is created, a corresponding Kinesis Firehose delivery stream is provisioned automatically.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | Health check |
+| POST | `/endpoints` | Create a new ingestion endpoint |
+| GET | `/endpoints` | List all endpoints (query params: `domain`, `order_by`) |
+| GET | `/endpoints/{domain}/{name}` | Get a specific endpoint (query param: `version`) |
+| PUT | `/endpoints/{domain}/{name}` | Update endpoint schema (creates new version) |
+| DELETE | `/endpoints/{domain}/{name}` | Delete endpoint and all its versions |
+| GET | `/endpoints/{domain}/{name}/versions` | List all schema versions |
+| GET | `/endpoints/{domain}/{name}/yaml` | Get raw YAML schema definition |
+| GET | `/endpoints/{domain}/{name}/download` | Get presigned URL to download YAML schema |
+| POST | `/endpoints/infer` | Infer schema from a sample JSON payload |
+
+**Request — `POST /endpoints`**
+```json
+{
+  "name": "my_table",
+  "domain": "sales",
+  "mode": "MANUAL",
+  "columns": [
+    {
+      "name": "order_id",
+      "type": "integer",
+      "required": true,
+      "primary_key": true,
+      "description": "Unique order identifier"
+    }
+  ],
+  "description": "Sales orders endpoint"
+}
+```
+
+**Response**
+```json
+{
+  "id": "sales/my_table",
+  "name": "my_table",
+  "domain": "sales",
+  "version": 1,
+  "mode": "MANUAL",
+  "endpoint_url": "https://<api>/ingest/sales/my_table",
+  "schema_url": "https://<api>/endpoints/sales/my_table/download",
+  "status": "active",
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z"
+}
+```
+
+**Schema modes:** `MANUAL` (user defines columns), `AUTO_INFERENCE` (inferred from first payload), `SINGLE_COLUMN` (raw payload stored as-is).
+
+**Column types:** `string`, `integer`, `float`, `boolean`, `timestamp`, `date`, `json`, `array`, `decimal`.
+
+---
+
+### 2. Ingestion API (`/ingest`) — Data Ingestion
+
+Receives data records, validates them against the endpoint schema, and sends them to Kinesis Firehose for landing in the bronze layer.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/ingest/{domain}/{endpoint_name}` | Ingest a single record |
+| POST | `/ingest/{domain}/{endpoint_name}/batch` | Ingest multiple records |
+
+**Query parameters:**
+- `validate` (bool, default: `true`) — validate payload against schema
+- `strict` (bool, default: `false`) — reject the request if validation fails
+
+**Request — single record**
+```json
+{
+  "data": {
+    "order_id": 123,
+    "product": "Widget",
+    "amount": 49.90
+  }
+}
+```
+
+**Request — batch**
+```json
+[
+  {"order_id": 123, "product": "Widget", "amount": 49.90},
+  {"order_id": 124, "product": "Gadget", "amount": 29.90}
+]
+```
+
+**Response — single**
+```json
+{
+  "status": "sent",
+  "endpoint": "sales/my_table",
+  "records_sent": 1,
+  "validated": true
+}
+```
+
+**Response — batch**
+```json
+{
+  "status": "completed",
+  "endpoint": "sales/my_table",
+  "total_records": 2,
+  "validated_count": 2,
+  "sent_count": 2
+}
+```
+
+Metadata fields `_insert_date`, `_domain`, and `_endpoint` are automatically added to each record.
+
+---
+
+### 3. Query API (`/consumption`) — Data Consumption
+
+Executes SQL queries against the data lake using DuckDB, with transparent table reference rewriting.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/consumption/query` | Execute a SQL query |
+| GET | `/consumption/tables` | List all available silver tables |
+
+**Query parameters (for `/consumption/query`):**
+- `sql` (string, required) — SQL query to execute
+
+**Table reference syntax in queries:**
+
+| Reference | Resolves to |
+|-----------|-------------|
+| `domain.bronze.table` | `read_json_auto('s3://bucket/firehose-data/domain/table/**')` |
+| `domain.silver.table` | Glue Iceberg catalog `domain_silver.table` |
+| `domain.gold.table` | Glue Iceberg catalog `domain_gold.table` |
+
+**Example**
+```
+GET /consumption/query?sql=SELECT * FROM sales.silver.my_table LIMIT 10
+```
+
+**Response**
+```json
+{
+  "data": [
+    {"order_id": 123, "product": "Widget", "amount": 49.90}
+  ],
+  "row_count": 1
+}
+```
+
+---
+
+### 4. Transform Jobs API (`/transform`) — Gold Layer Transforms
+
+CRUD for transform job definitions and triggering executions via Step Functions + ECS Fargate (dbt runner).
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/` | Health check |
+| POST | `/transform/jobs` | Create a new transform job |
+| GET | `/transform/jobs` | List all jobs (query params: `domain`, `order_by`) |
+| GET | `/transform/jobs/{domain}/{job_name}` | Get a specific job |
+| PUT | `/transform/jobs/{domain}/{job_name}` | Update a transform job |
+| DELETE | `/transform/jobs/{domain}/{job_name}` | Delete a transform job |
+| POST | `/transform/jobs/{domain}/{job_name}/run` | Trigger job execution |
+| GET | `/transform/executions/{execution_id}` | Get execution status |
+
+**Request — `POST /transform/jobs`**
+```json
+{
+  "domain": "sales",
+  "job_name": "daily_revenue",
+  "query": "SELECT date, SUM(amount) as revenue FROM sales.silver.orders GROUP BY date",
+  "write_mode": "overwrite",
+  "unique_key": "date",
+  "schedule_type": "cron",
+  "cron_schedule": "0 2 * * ? *"
+}
+```
+
+**Response**
+```json
+{
+  "id": "sales/daily_revenue",
+  "domain": "sales",
+  "job_name": "daily_revenue",
+  "query": "SELECT date, SUM(amount) as revenue FROM sales.silver.orders GROUP BY date",
+  "write_mode": "overwrite",
+  "unique_key": "date",
+  "schedule_type": "cron",
+  "cron_schedule": "0 2 * * ? *",
+  "status": "active",
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z"
+}
+```
+
+**Trigger execution — `POST /transform/jobs/{domain}/{job_name}/run`**
+```json
+{
+  "execution_id": "arn:aws:states:...:execution:...",
+  "job_name": "daily_revenue",
+  "domain": "sales",
+  "status": "RUNNING",
+  "started_at": "2025-01-01T02:00:00Z"
+}
+```
+
+**Write modes:** `overwrite`, `append`.
+**Schedule types:** `cron` (time-based), `dependency` (triggered by upstream jobs).
+
+---
+
+### Background Services (event-driven, no API routes)
+
+These services are not exposed through the API Gateway but are triggered by events:
+
+| Service | Trigger | Description |
+|---------|---------|-------------|
+| **Processing (Iceberg)** | S3 event (object created in bronze bucket) | Reads raw data from bronze, applies schema, performs merge/upsert, and writes to silver layer as Iceberg tables via Glue catalog |
+| **Analytics** | EventBridge scheduled rules | Runs pre-configured SQL analytics jobs on a schedule and writes results to the gold layer |
+
+### Transform Pipeline (Step Functions + ECS Fargate)
+
+Gold layer transformations run on ECS Fargate via Step Functions with a dbt runner container:
+
+- **Single mode** — triggered via `POST /transform/jobs/{domain}/{job_name}/run`, executes one job
+- **Scheduled mode** — triggered by EventBridge on preset schedules (`hourly`, `daily` at 2 AM UTC, `monthly` at 3 AM UTC on the 1st), runs all jobs matching the schedule tag


### PR DESCRIPTION
## Summary
Added detailed API reference documentation to the README covering all four main API services and background event-driven services in the data lake platform.

## Changes
- **Endpoints API** (`/endpoints`) — Complete schema registry documentation with request/response examples, supported column types, and schema modes (MANUAL, AUTO_INFERENCE, SINGLE_COLUMN)
- **Ingestion API** (`/ingest`) — Data ingestion endpoints with single record and batch ingestion examples, validation options, and automatic metadata field injection
- **Query API** (`/consumption`) — SQL query execution against the data lake with transparent table reference rewriting for bronze/silver/gold layers
- **Transform Jobs API** (`/transform`) — CRUD operations for transform job definitions, execution triggering, and scheduling (cron-based and dependency-based)
- **Background Services** — Documentation of event-driven services (Processing/Iceberg and Analytics) that operate without direct API routes
- **Transform Pipeline** — Details on Step Functions + ECS Fargate integration for dbt-based gold layer transformations with single and scheduled execution modes

## Notable Details
- All endpoints served through API Gateway with FastAPI + Mangum for Lambda integration
- CORS enabled on all endpoints
- Automatic Kinesis Firehose provisioning when endpoints are created
- Metadata fields (`_insert_date`, `_domain`, `_endpoint`) automatically added to ingested records
- Table reference syntax supports transparent rewriting across bronze/silver/gold layers
- Multiple scheduling options: cron expressions, hourly, daily (2 AM UTC), and monthly (3 AM UTC on 1st)

https://claude.ai/code/session_018BVkHAhpefvEatTyaxgc53