### PR TITLE
Add column descriptions to manual schema form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 package-lock.json
+node_modules
 __pycache__
 .pytest_cache
 .venv

--- a/frontend/src/components/ingestion/ManualSchemaForm.jsx
+++ b/frontend/src/components/ingestion/ManualSchemaForm.jsx
@@ -20,7 +20,7 @@ export default function ManualSchemaForm({ columns, onColumnsChange }) {
   const addColumn = () => {
     onColumnsChange([
       ...columns,
-      { column_name: '', data_type: 'varchar', required: false, is_primary_key: false }
+      { column_name: '', data_type: 'varchar', required: false, is_primary_key: false, description: '' }
     ]);
   };
 
@@ -43,72 +43,87 @@ export default function ManualSchemaForm({ columns, onColumnsChange }) {
         <div
           key={index}
           className={cn(
-            "flex items-center gap-3 p-3 rounded-2xl border-2 transition-all",
+            "p-3 rounded-2xl border-2 transition-all space-y-2",
             column.is_primary_key
               ? "bg-[#C4B5FD] border-[#A78BFA]"
               : "bg-white border-gray-200"
           )}
           style={{ boxShadow: '3px 3px 0 rgba(0,0,0,0.05)' }}
         >
-          {/* Column name */}
+          <div className="flex items-center gap-3">
+            {/* Column name */}
+            <input
+              placeholder="column_name"
+              value={column.column_name}
+              onChange={(e) => updateColumn(index, 'column_name', e.target.value)}
+              className="flex-1 px-3 py-2 rounded-xl border-2 border-gray-200 font-mono text-sm focus:border-[#A8E6CF] focus:outline-none"
+            />
+
+            {/* Data type */}
+            <Select
+              value={column.data_type}
+              onValueChange={(value) => updateColumn(index, 'data_type', value)}
+            >
+              <SelectTrigger className="w-32 border-2 border-gray-200 rounded-xl">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent className="rounded-xl">
+                {DATA_TYPES.map(type => (
+                  <SelectItem key={type.value} value={type.value}>
+                    <span className="font-mono text-sm">{type.label}</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            {/* Required */}
+            <label className="flex items-center gap-1.5 cursor-pointer">
+              <Checkbox
+                checked={column.required}
+                onCheckedChange={(checked) => updateColumn(index, 'required', checked)}
+                className="border-2 data-[state=checked]:bg-[#A8E6CF] data-[state=checked]:border-[#6BCF9F]"
+              />
+              <span className="text-xs text-gray-500">Req</span>
+            </label>
+
+            {/* Primary Key */}
+            <label className="flex items-center gap-1.5 cursor-pointer">
+              <Checkbox
+                checked={column.is_primary_key}
+                onCheckedChange={(checked) => updateColumn(index, 'is_primary_key', checked)}
+                className="border-2 data-[state=checked]:bg-[#C4B5FD] data-[state=checked]:border-[#A78BFA]"
+              />
+              <Key className={cn("w-3.5 h-3.5", column.is_primary_key ? "text-[#5B21B6]" : "text-gray-400")} />
+            </label>
+
+            {/* Delete */}
+            <button
+              type="button"
+              onClick={() => removeColumn(index)}
+              disabled={columns.length === 1}
+              className={cn(
+                "p-2 rounded-xl transition-colors",
+                columns.length > 1
+                  ? "text-gray-400 hover:text-[#991B1B] hover:bg-[#FEE2E2]"
+                  : "text-gray-200 cursor-not-allowed"
+              )}
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Description */}
           <input
-            placeholder="column_name"
-            value={column.column_name}
-            onChange={(e) => updateColumn(index, 'column_name', e.target.value)}
-            className="flex-1 px-3 py-2 rounded-xl border-2 border-gray-200 font-mono text-sm focus:border-[#A8E6CF] focus:outline-none"
-          />
-
-          {/* Data type */}
-          <Select
-            value={column.data_type}
-            onValueChange={(value) => updateColumn(index, 'data_type', value)}
-          >
-            <SelectTrigger className="w-32 border-2 border-gray-200 rounded-xl">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent className="rounded-xl">
-              {DATA_TYPES.map(type => (
-                <SelectItem key={type.value} value={type.value}>
-                  <span className="font-mono text-sm">{type.label}</span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-
-          {/* Required */}
-          <label className="flex items-center gap-1.5 cursor-pointer">
-            <Checkbox
-              checked={column.required}
-              onCheckedChange={(checked) => updateColumn(index, 'required', checked)}
-              className="border-2 data-[state=checked]:bg-[#A8E6CF] data-[state=checked]:border-[#6BCF9F]"
-            />
-            <span className="text-xs text-gray-500">Req</span>
-          </label>
-
-          {/* Primary Key */}
-          <label className="flex items-center gap-1.5 cursor-pointer">
-            <Checkbox
-              checked={column.is_primary_key}
-              onCheckedChange={(checked) => updateColumn(index, 'is_primary_key', checked)}
-              className="border-2 data-[state=checked]:bg-[#C4B5FD] data-[state=checked]:border-[#A78BFA]"
-            />
-            <Key className={cn("w-3.5 h-3.5", column.is_primary_key ? "text-[#5B21B6]" : "text-gray-400")} />
-          </label>
-
-          {/* Delete */}
-          <button
-            type="button"
-            onClick={() => removeColumn(index)}
-            disabled={columns.length === 1}
+            placeholder="Column description (helps AI agents understand this field)"
+            value={column.description || ''}
+            onChange={(e) => updateColumn(index, 'description', e.target.value)}
             className={cn(
-              "p-2 rounded-xl transition-colors",
-              columns.length > 1
-                ? "text-gray-400 hover:text-[#991B1B] hover:bg-[#FEE2E2]"
-                : "text-gray-200 cursor-not-allowed"
+              "w-full px-3 py-1.5 rounded-xl border-2 text-xs focus:outline-none transition-colors",
+              column.is_primary_key
+                ? "border-[#A78BFA]/50 bg-[#DDD6FE]/50 placeholder-[#7C3AED]/40 focus:border-[#7C3AED]"
+                : "border-gray-100 bg-gray-50 placeholder-gray-300 focus:border-[#A8E6CF]"
             )}
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
+          />
         </div>
       ))}
 

--- a/frontend/src/components/ingestion/__tests__/EndpointCreation.test.jsx
+++ b/frontend/src/components/ingestion/__tests__/EndpointCreation.test.jsx
@@ -183,7 +183,7 @@ describe('Endpoint Creation Flow', () => {
         domain: 'sales',
         mode: 'manual',
         columns: expect.arrayContaining([
-          expect.objectContaining({ name: 'id' })
+          expect.objectContaining({ name: 'id', description: null })
         ]),
       });
     });

--- a/frontend/src/components/ingestion/__tests__/ManualSchemaForm.test.jsx
+++ b/frontend/src/components/ingestion/__tests__/ManualSchemaForm.test.jsx
@@ -6,7 +6,7 @@ describe('ManualSchemaForm', () => {
   const mockOnColumnsChange = vi.fn();
 
   const defaultColumns = [
-    { column_name: '', data_type: 'varchar', required: false, is_primary_key: false }
+    { column_name: '', data_type: 'varchar', required: false, is_primary_key: false, description: '' }
   ];
 
   beforeEach(() => {
@@ -34,7 +34,7 @@ describe('ManualSchemaForm', () => {
 
     expect(mockOnColumnsChange).toHaveBeenCalledWith([
       ...defaultColumns,
-      { column_name: '', data_type: 'varchar', required: false, is_primary_key: false }
+      { column_name: '', data_type: 'varchar', required: false, is_primary_key: false, description: '' }
     ]);
   });
 
@@ -59,7 +59,7 @@ describe('ManualSchemaForm', () => {
     fireEvent.change(input, { target: { value: 'user_id' } });
 
     expect(mockOnColumnsChange).toHaveBeenCalledWith([
-      { column_name: 'user_id', data_type: 'varchar', required: false, is_primary_key: false }
+      { column_name: 'user_id', data_type: 'varchar', required: false, is_primary_key: false, description: '' }
     ]);
   });
 
@@ -131,5 +131,35 @@ describe('ManualSchemaForm', () => {
     // Look for the select trigger
     const selectTrigger = screen.getByRole('combobox');
     expect(selectTrigger).toBeInTheDocument();
+  });
+
+  it('renders description input for each column', () => {
+    render(<ManualSchemaForm columns={defaultColumns} onColumnsChange={mockOnColumnsChange} />);
+
+    const descInput = screen.getByPlaceholderText(/column description/i);
+    expect(descInput).toBeInTheDocument();
+    expect(descInput.value).toBe('');
+  });
+
+  it('updates column description when typing', () => {
+    render(<ManualSchemaForm columns={defaultColumns} onColumnsChange={mockOnColumnsChange} />);
+
+    const descInput = screen.getByPlaceholderText(/column description/i);
+    fireEvent.change(descInput, { target: { value: 'Unique user identifier' } });
+
+    expect(mockOnColumnsChange).toHaveBeenCalledWith([
+      { column_name: '', data_type: 'varchar', required: false, is_primary_key: false, description: 'Unique user identifier' }
+    ]);
+  });
+
+  it('renders description with existing value', () => {
+    const columnsWithDesc = [
+      { column_name: 'user_id', data_type: 'integer', required: true, is_primary_key: true, description: 'Primary user ID' }
+    ];
+
+    render(<ManualSchemaForm columns={columnsWithDesc} onColumnsChange={mockOnColumnsChange} />);
+
+    const descInput = screen.getByPlaceholderText(/column description/i);
+    expect(descInput.value).toBe('Primary user ID');
   });
 });

--- a/frontend/src/pages/DataPlatform.jsx
+++ b/frontend/src/pages/DataPlatform.jsx
@@ -58,7 +58,7 @@ export default function DataPlatform() {
   const [tableName, setTableName] = useState('');
   const [schemaMode, setSchemaMode] = useState('manual');
   const [columns, setColumns] = useState([
-    { name: '', type: 'string', required: false, primary_key: false }
+    { name: '', type: 'string', required: false, primary_key: false, description: '' }
   ]);
   const [createdEndpoint, setCreatedEndpoint] = useState(null);
   const [validationError, setValidationError] = useState('');
@@ -198,6 +198,7 @@ export default function DataPlatform() {
         type: col.type || col.data_type || 'string',
         required: col.required || false,
         primary_key: col.primary_key || col.is_primary_key || false,
+        description: col.description || null,
       }));
     } else if (schemaMode === 'single_column') {
       schemaColumns = [{ name: 'data', type: 'json', required: true, primary_key: false }];
@@ -210,7 +211,7 @@ export default function DataPlatform() {
 
   const resetForm = () => {
     setDomain(''); setTableName(''); setSchemaMode('manual');
-    setColumns([{ name: '', type: 'string', required: false, primary_key: false }]);
+    setColumns([{ name: '', type: 'string', required: false, primary_key: false, description: '' }]);
     setCreatedEndpoint(null); setValidationError('');
   };
 


### PR DESCRIPTION
## Summary
This PR adds support for column descriptions in the manual schema form, allowing users to provide documentation for each column that helps AI agents understand the purpose and context of fields.

## Key Changes
- **ManualSchemaForm component**: 
  - Added `description` field to the column object structure
  - Restructured the layout from a single-row flex layout to a multi-row layout using `space-y-2` to accommodate the new description input
  - Added a new description input field below the column configuration controls with contextual styling that adapts based on whether the column is a primary key
  - Updated the "Add Column" functionality to initialize the `description` field as an empty string

- **DataPlatform page**:
  - Updated initial column state to include the `description` field
  - Modified the schema column mapping logic to include and preserve the `description` field when building the final schema

- **Tests**:
  - Updated all test fixtures to include the `description` field in column objects
  - Added three new test cases to verify description input rendering, updating, and persistence
  - Updated endpoint creation test expectations to include `description: null` in the column object

- **Build configuration**:
  - Added `node_modules` to `.gitignore`

## Implementation Details
- The description input uses conditional styling: primary key columns get a purple-tinted background, while regular columns use a gray background
- The description field is optional and defaults to an empty string in the UI, but can be `null` in the API payload
- The layout change from horizontal to vertical stacking improves readability and provides adequate space for the description input field

https://claude.ai/code/session_011gCVySLWb3n7AWTeRkyyR8