### PR TITLE
Use S3SessionManager for automatic conversation memory

### DIFF
--- a/lambdas/chat_api/agent.py
+++ b/lambdas/chat_api/agent.py
@@ -3,6 +3,7 @@ Strands Agent setup for analytics chat.
 
 Creates a Bedrock-powered agent with SQL execution and auto-chart generation,
 using table metadata from the Schema Registry as context.
+Uses S3SessionManager for automatic conversation memory persistence.
 """
 
 import logging
@@ -12,6 +13,7 @@ from typing import List, Optional
 from pydantic import BaseModel, Field
 from strands import Agent
 from strands.models import BedrockModel
+from strands.session.s3_session_manager import S3SessionManager
 
 from prompt import build_system_prompt
 from tools import execute_sql
@@ -21,6 +23,7 @@ logger = logging.getLogger(__name__)
 BEDROCK_MODEL_ID = os.environ.get(
     "BEDROCK_MODEL_ID", "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
 )
+SCHEMA_BUCKET = os.environ.get("SCHEMA_BUCKET", "")
 
 
 class ChartSpec(BaseModel):
@@ -51,56 +54,67 @@ def _create_model() -> BedrockModel:
     )
 
 
-def create_agent(tables_metadata: list[dict]) -> Agent:
+def create_agent(tables_metadata: list[dict], session_id: str | None = None) -> Agent:
     """
     Create a Strands agent configured for analytics chat.
 
+    When a session_id is provided, the agent uses S3SessionManager to
+    automatically load previous conversation messages and persist new ones,
+    giving the chat full multi-turn memory.
+
     Args:
         tables_metadata: List of table dicts from the catalog API.
+        session_id: Chat session ID for conversation memory persistence.
 
     Returns:
         Configured Strands Agent ready to process messages.
     """
     system_prompt = build_system_prompt(tables_metadata)
 
-    return Agent(
+    kwargs = dict(
         model=_create_model(),
         system_prompt=system_prompt,
         tools=[execute_sql],
         structured_output_model=AnalysisResponse,
     )
 
+    if session_id and SCHEMA_BUCKET:
+        kwargs["session_manager"] = S3SessionManager(
+            session_id=session_id,
+            bucket=SCHEMA_BUCKET,
+            prefix="chat_sessions/",
+        )
 
-def run_agent(
-    agent: Agent,
-    message: str,
-    agent_messages: list[dict] | None = None,
-) -> dict:
+    return Agent(**kwargs)
+
+
+def run_agent(agent: Agent, message: str) -> dict:
     """
-    Run the agent with a user message and optional conversation history.
+    Run the agent with a user message.
+
+    Conversation history is managed automatically by the S3SessionManager
+    configured on the agent — previous messages are loaded on agent creation
+    and new messages are persisted after each call.
 
     Args:
-        agent: The Strands agent instance.
+        agent: The Strands agent instance (with session_manager for memory).
         message: The user's message.
-        agent_messages: Raw Strands messages from previous turns (includes tool use/results).
 
     Returns:
-        Dict with 'content' (list of text/chart blocks) and 'agent_messages' (raw history).
+        Dict with 'content' (list of text/chart/suggestion blocks).
     """
     try:
-        result = agent(message, messages=agent_messages if agent_messages else None)
+        result = agent(message)
     except Exception as e:
         logger.error(f"Agent error: {e}")
         return {
             "content": [{"type": "text", "text": f"Sorry, I encountered an error: {str(e)}"}],
-            "agent_messages": agent_messages or [],
         }
 
     content_blocks = _parse_agent_response(result.structured_output)
 
     return {
         "content": content_blocks,
-        "agent_messages": agent.messages,
     }
 
 

--- a/lambdas/chat_api/chat_store.py
+++ b/lambdas/chat_api/chat_store.py
@@ -9,7 +9,9 @@ Layout::
 
     s3://{bucket}/chat_sessions/{session_id}/metadata.json
     s3://{bucket}/chat_sessions/{session_id}/messages/{timestamp}_{message_id}.json
-    s3://{bucket}/chat_sessions/{session_id}/agent_context.json
+
+Note: Agent conversation memory is managed by Strands S3SessionManager
+(configured in agent.py) under the same prefix.
 """
 
 import json
@@ -66,10 +68,6 @@ def _metadata_key(session_id: str) -> str:
 
 def _messages_prefix(session_id: str) -> str:
     return f"{PREFIX}/{session_id}/messages/"
-
-
-def _agent_context_key(session_id: str) -> str:
-    return f"{PREFIX}/{session_id}/agent_context.json"
 
 
 # ---------------------------------------------------------------------------
@@ -186,19 +184,6 @@ def get_messages(session_id: str) -> list[dict]:
     # Keys are timestamp-prefixed so sort is chronological
     messages.sort(key=lambda m: m.get("created_at", ""))
     return messages
-
-
-def save_agent_context(session_id: str, agent_messages: list[dict]) -> None:
-    """Save the raw Strands agent messages for a session."""
-    _put_json(_agent_context_key(session_id), {"messages": agent_messages})
-
-
-def load_agent_context(session_id: str) -> list[dict] | None:
-    """Load the raw Strands agent messages for a session."""
-    data = _get_json(_agent_context_key(session_id))
-    if not data or "messages" not in data:
-        return None
-    return data["messages"]
 
 
 def delete_session(session_id: str) -> bool:

--- a/lambdas/chat_api/main.py
+++ b/lambdas/chat_api/main.py
@@ -102,24 +102,16 @@ async def send_message(request: SendMessageRequest) -> SendMessageResponse:
     user_content = [{"type": "text", "text": request.message}]
     chat_store.add_message(session_id, "user", user_content)
 
-    # Load raw agent messages from previous turns (includes tool use/results)
-    agent_messages = chat_store.load_agent_context(session_id)
-
-    # Fetch table metadata and create agent
+    # Fetch table metadata and create agent with session memory
     tables_metadata = _fetch_tables_metadata()
-    agent = create_agent(tables_metadata)
+    agent = create_agent(tables_metadata, session_id=session_id)
 
-    # Run the agent with full conversation context
-    result = run_agent(agent, request.message, agent_messages)
+    # Run the agent — S3SessionManager handles conversation memory automatically
+    result = run_agent(agent, request.message)
 
     # Save assistant response (for UI display)
     assistant_content = result.get("content", [])
     assistant_msg = chat_store.add_message(session_id, "assistant", assistant_content)
-
-    # Persist raw agent messages for next turn's context
-    raw_messages = result.get("agent_messages", [])
-    if raw_messages:
-        chat_store.save_agent_context(session_id, raw_messages)
 
     return SendMessageResponse(
         session_id=session_id,


### PR DESCRIPTION
## Summary
Refactored conversation memory management to use Strands' built-in `S3SessionManager` instead of manually persisting and loading agent messages. This simplifies the codebase and leverages the framework's native session handling.

## Key Changes
- **agent.py**: 
  - Added `S3SessionManager` import and integration
  - Added `SCHEMA_BUCKET` environment variable for session storage
  - Modified `create_agent()` to accept optional `session_id` and configure `S3SessionManager` when provided
  - Simplified `run_agent()` to remove `agent_messages` parameter; conversation history is now managed automatically by the session manager
  - Updated docstrings to reflect automatic memory persistence

- **chat_store.py**:
  - Removed `save_agent_context()` and `load_agent_context()` functions
  - Removed `_agent_context_key()` helper function
  - Updated module docstring to clarify that agent memory is now managed by Strands' S3SessionManager

- **main.py**:
  - Removed manual loading of agent context before creating the agent
  - Removed manual persistence of agent messages after running the agent
  - Pass `session_id` to `create_agent()` to enable automatic session management
  - Simplified `run_agent()` call to only pass the message

## Implementation Details
The `S3SessionManager` is configured with:
- `session_id`: Chat session identifier
- `bucket`: S3 bucket from `SCHEMA_BUCKET` environment variable
- `prefix`: `"chat_sessions/"` for organized storage

This approach provides multi-turn conversation memory automatically—previous messages are loaded when the agent is created, and new messages are persisted after each agent call, eliminating the need for manual context management in the API layer.

https://claude.ai/code/session_01HQvQqn82bEJkKzuMHTEe9z