### PR TITLE
Clarify timestamp conversion guidance for Unix epoch formats

### DIFF
--- a/lambdas/transformation_agent/agents/transformation_agent/analyzer.py
+++ b/lambdas/transformation_agent/agents/transformation_agent/analyzer.py
@@ -39,7 +39,13 @@ You will receive:
   window functions, CTEs, QUALIFY, EXCLUDE, REPLACE, etc.
 - IMPORTANT: Do NOT use functions or syntax that DuckDB does not support. \
   Stick to standard SQL with DuckDB extensions.
-- For timestamps: use `CAST(col AS DATE)` or `DATE_TRUNC('day', col)` for grouping.
+- For timestamps stored as Unix epoch **milliseconds** (e.g., `datainclusao`, `created_at_ms`): \
+  use `epoch_ms(col)` to convert to TIMESTAMP, then wrap with `CAST(epoch_ms(col) AS DATE)` or \
+  `DATE_TRUNC('day', epoch_ms(col))` for date grouping. \
+  NEVER use `FROM_TIMESTAMP` — it does not exist in DuckDB.
+- For timestamps stored as Unix epoch **seconds**: use `to_timestamp(col)`.
+- For columns that are already a TIMESTAMP or DATE type: use `CAST(col AS DATE)` or \
+  `DATE_TRUNC('day', col)` directly.
 
 ### DuckDB UNNEST / Array / JSON rules — READ CAREFULLY
 - UNNEST CANNOT be used inside SELECT expressions or aggregate functions. \


### PR DESCRIPTION
## Summary
Updated the transformation agent's analyzer prompt to provide clearer and more specific guidance on handling different timestamp formats in DuckDB, particularly distinguishing between Unix epoch milliseconds, seconds, and native timestamp/date types.

## Key Changes
- **Expanded timestamp conversion documentation** with explicit handling for three distinct timestamp scenarios:
  - Unix epoch **milliseconds** (e.g., `datainclusao`, `created_at_ms`): use `epoch_ms(col)` function
  - Unix epoch **seconds**: use `to_timestamp(col)` function
  - Native TIMESTAMP/DATE types: use `CAST(col AS DATE)` or `DATE_TRUNC('day', col)` directly
- **Added explicit warning** against using `FROM_TIMESTAMP`, which does not exist in DuckDB
- **Clarified wrapping patterns** for date grouping operations with epoch-converted timestamps

## Implementation Details
The changes improve the prompt's specificity by:
1. Naming common millisecond-based timestamp columns as examples
2. Providing the correct DuckDB function (`epoch_ms`) for millisecond conversion
3. Distinguishing the conversion approach for seconds-based epochs
4. Preventing a common error by explicitly calling out that `FROM_TIMESTAMP` is not available
5. Maintaining clear guidance for already-typed timestamp columns

This should reduce transformation errors when agents encounter various timestamp storage formats in source data.

https://claude.ai/code/session_014GAHTzhcirA8ofQ2yxTqH2