### PR TITLE
Handle API Gateway timeouts with polling in chat interface

### DIFF
--- a/frontend/src/components/analyze/ChatInterface.jsx
+++ b/frontend/src/components/analyze/ChatInterface.jsx
@@ -40,11 +40,14 @@ export default function ChatInterface() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  // Poll session until an assistant message appears (handles API Gateway 29s timeout).
+  // Retry fetching session after API Gateway timeout (29s hard limit).
   // The Lambda keeps running after the timeout and saves the result to S3.
+  // Uses 3 attempts with increasing delays (10s → 15s → 20s) to minimise
+  // extra Lambda invocations — only triggered on actual timeout errors.
   const pollForResponse = async (sessionId) => {
-    for (let i = 0; i < 8; i++) {
-      await new Promise(r => setTimeout(r, 3000));
+    const delays = [10000, 15000, 20000];
+    for (const delay of delays) {
+      await new Promise(r => setTimeout(r, delay));
       try {
         const data = await dataLakeApi.chat.getSession(sessionId);
         const msgs = data.messages || [];
@@ -53,16 +56,17 @@ export default function ChatInterface() {
           return true;
         }
       } catch {
-        // continue polling
+        // continue to next attempt
       }
     }
     return false;
   };
 
-  // For first-message 503: poll sessions list to find the newly created session.
+  // For first-message 503: retry sessions list to find the newly created session.
   const pollForNewSession = async (knownSessionIds) => {
-    for (let i = 0; i < 8; i++) {
-      await new Promise(r => setTimeout(r, 3000));
+    const delays = [10000, 15000, 20000];
+    for (const delay of delays) {
+      await new Promise(r => setTimeout(r, delay));
       try {
         const latestSessions = await dataLakeApi.chat.getSessions();
         const newSession = latestSessions.find(s => !knownSessionIds.has(s.session_id));
@@ -77,7 +81,7 @@ export default function ChatInterface() {
           }
         }
       } catch {
-        // continue polling
+        // continue to next attempt
       }
     }
     return false;

--- a/frontend/src/components/analyze/ChatInterface.jsx
+++ b/frontend/src/components/analyze/ChatInterface.jsx
@@ -13,6 +13,8 @@ export default function ChatInterface() {
   const [isLoading, setIsLoading] = useState(false);
   const messagesEndRef = useRef(null);
   const queryClient = useQueryClient();
+  // Prevents useEffect from overwriting messages while handleSend is in progress
+  const isHandlingSendRef = useRef(false);
 
   // Fetch sessions list
   const { data: sessions = [] } = useQuery({
@@ -26,6 +28,8 @@ export default function ChatInterface() {
       setMessages([]);
       return;
     }
+    // Skip while handleSend is managing messages to avoid race conditions
+    if (isHandlingSendRef.current) return;
     dataLakeApi.chat.getSession(activeSessionId)
       .then(data => setMessages(data.messages || []))
       .catch(() => setMessages([]));
@@ -36,7 +40,55 @@ export default function ChatInterface() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  // Poll session until an assistant message appears (handles API Gateway 29s timeout).
+  // The Lambda keeps running after the timeout and saves the result to S3.
+  const pollForResponse = async (sessionId) => {
+    for (let i = 0; i < 8; i++) {
+      await new Promise(r => setTimeout(r, 3000));
+      try {
+        const data = await dataLakeApi.chat.getSession(sessionId);
+        const msgs = data.messages || [];
+        if (msgs.length > 0 && msgs[msgs.length - 1].role === 'assistant') {
+          setMessages(msgs);
+          return true;
+        }
+      } catch {
+        // continue polling
+      }
+    }
+    return false;
+  };
+
+  // For first-message 503: poll sessions list to find the newly created session.
+  const pollForNewSession = async (knownSessionIds) => {
+    for (let i = 0; i < 8; i++) {
+      await new Promise(r => setTimeout(r, 3000));
+      try {
+        const latestSessions = await dataLakeApi.chat.getSessions();
+        const newSession = latestSessions.find(s => !knownSessionIds.has(s.session_id));
+        if (newSession) {
+          const data = await dataLakeApi.chat.getSession(newSession.session_id);
+          const msgs = data.messages || [];
+          if (msgs.length > 0 && msgs[msgs.length - 1].role === 'assistant') {
+            setActiveSessionId(newSession.session_id);
+            setMessages(msgs);
+            queryClient.invalidateQueries({ queryKey: ['chatSessions'] });
+            return true;
+          }
+        }
+      } catch {
+        // continue polling
+      }
+    }
+    return false;
+  };
+
   const handleSend = async (text) => {
+    isHandlingSendRef.current = true;
+    // Snapshot known sessions before the request (used for new-session polling)
+    const knownSessionIds = new Set((sessions || []).map(s => s.session_id));
+    const currentSessionId = activeSessionId;
+
     // Optimistically add user message
     const userMsg = {
       message_id: `temp-${Date.now()}`,
@@ -48,10 +100,10 @@ export default function ChatInterface() {
     setIsLoading(true);
 
     try {
-      const response = await dataLakeApi.chat.sendMessage(activeSessionId, text);
+      const response = await dataLakeApi.chat.sendMessage(currentSessionId, text);
 
       // If a new session was created, set it as active
-      if (!activeSessionId && response.session_id) {
+      if (!currentSessionId && response.session_id) {
         setActiveSessionId(response.session_id);
         queryClient.invalidateQueries({ queryKey: ['chatSessions'] });
       }
@@ -65,14 +117,39 @@ export default function ChatInterface() {
       };
       setMessages(prev => [...prev, assistantMsg]);
     } catch (error) {
-      // Show error as assistant message
-      setMessages(prev => [...prev, {
-        message_id: `error-${Date.now()}`,
-        role: 'assistant',
-        content: [{ type: 'text', text: `Error: ${error.message || 'Failed to get response'}` }],
-        created_at: new Date().toISOString(),
-      }]);
+      // API Gateway times out at 29s but the Lambda keeps processing.
+      // Poll for the saved result instead of immediately showing the error.
+      const isTimeout =
+        error.message === 'Service Unavailable' ||
+        error.message === 'Endpoint request timed out' ||
+        error.message?.includes('Gateway Timeout') ||
+        error.message?.includes('503') ||
+        error.message?.includes('504');
+
+      if (isTimeout) {
+        const found = currentSessionId
+          ? await pollForResponse(currentSessionId)
+          : await pollForNewSession(knownSessionIds);
+
+        if (!found) {
+          setMessages(prev => [...prev, {
+            message_id: `error-${Date.now()}`,
+            role: 'assistant',
+            content: [{ type: 'text', text: 'A resposta demorou mais que o esperado. Por favor, tente novamente.' }],
+            created_at: new Date().toISOString(),
+          }]);
+        }
+      } else {
+        // Show error as assistant message for other error types
+        setMessages(prev => [...prev, {
+          message_id: `error-${Date.now()}`,
+          role: 'assistant',
+          content: [{ type: 'text', text: `Error: ${error.message || 'Failed to get response'}` }],
+          created_at: new Date().toISOString(),
+        }]);
+      }
     } finally {
+      isHandlingSendRef.current = false;
       setIsLoading(false);
       queryClient.invalidateQueries({ queryKey: ['chatSessions'] });
     }


### PR DESCRIPTION
## Summary
This PR adds resilience to the chat interface when API Gateway times out (29s hard limit). Instead of immediately showing an error, the client now polls for the response since the Lambda continues processing in the background and saves results to S3.

## Key Changes
- **Race condition prevention**: Added `isHandlingSendRef` to prevent `useEffect` from overwriting messages while `handleSend` is in progress
- **Timeout detection**: Detects timeout errors (503, 504, Gateway Timeout) and triggers polling instead of showing immediate error
- **Response polling**: Implemented `pollForResponse()` to retry fetching an existing session with exponential backoff (10s → 15s → 20s delays)
- **New session polling**: Implemented `pollForNewSession()` to handle first-message scenarios where the session is created after the timeout
- **Session snapshot**: Captures known session IDs before the request to identify newly created sessions during polling
- **User-friendly messaging**: Added Portuguese error message for timeout scenarios ("A resposta demorou mais que o esperado. Por favor, tente novamente.")

## Implementation Details
- Uses 3 polling attempts with increasing delays to minimize unnecessary Lambda invocations
- Only triggers polling on actual timeout errors; other errors show immediately
- Properly manages async state with `isHandlingSendRef` to prevent race conditions between `useEffect` and `handleSend`
- Maintains backward compatibility with existing error handling for non-timeout errors

https://claude.ai/code/session_011FpJEnNNZWiQMbomnPaE1P