### PR TITLE
Add OpenAPI spec discovery via Amazon Nova Web Grounding

### DIFF
--- a/containers/dbt_runner/.dockerignore
+++ b/containers/dbt_runner/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+*.md

--- a/containers/ingestion_runner/.dockerignore
+++ b/containers/ingestion_runner/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+*.md

--- a/containers/ingestion_runner/requirements.txt
+++ b/containers/ingestion_runner/requirements.txt
@@ -2,4 +2,4 @@ boto3>=1.35.0
 pydantic>=2.9.0
 pyyaml>=6.0.2
 httpx>=0.27.0
-dlt[rest_api]>=1.0.0
+dlt>=1.0.0

--- a/frontend/src/api/dataLakeClient.js
+++ b/frontend/src/api/dataLakeClient.js
@@ -246,6 +246,8 @@ const AgentClient = {
       client.request('/agent/ingestion/run', { method: 'POST', body: data }),
     getJob: async (jobId) =>
       client.request(`/agent/ingestion/jobs/${jobId}`),
+    discover: async (data) =>
+      client.request('/agent/ingestion/discover', { method: 'POST', body: data }),
   },
   transformation: {
     plan: async (data) =>

--- a/frontend/src/components/ai/AiPipeline.jsx
+++ b/frontend/src/components/ai/AiPipeline.jsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect, useCallback } from 'react';
 import dataLakeApi from '@/api/dataLakeClient';
 import {
   Sparkles, Database, Layers, Search, ArrowRight, Loader2,
-  CheckCircle2, XCircle, Link2, Globe, Tag, Play, ChevronDown, ChevronUp, Lock,
+  CheckCircle2, XCircle, Link2, Globe, Tag, Play, ChevronDown, ChevronUp, Lock, Wand2,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { cn } from '@/lib/utils';
@@ -159,6 +159,13 @@ export default function AiPipeline() {
   const [apiUrl, setApiUrl] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [authType, setAuthType] = useState('none');
+
+  // URL discovery state
+  const [urlMode, setUrlMode] = useState('search'); // 'search' | 'manual'
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
+  const [discoveredUrl, setDiscoveredUrl] = useState(null); // { url, title } | null
+  const [searchError, setSearchError] = useState(null);
   const [token, setToken] = useState('');
   // OAuth2 ROPC fields
   const [oauth2TokenUrl, setOauth2TokenUrl] = useState('');
@@ -185,6 +192,28 @@ export default function AiPipeline() {
   const addLog = useCallback((msg) => {
     setLogs(prev => [...prev, { ts: new Date().toLocaleTimeString(), msg }]);
   }, []);
+
+  const handleDiscover = useCallback(async () => {
+    if (!searchQuery.trim()) return;
+    setIsSearching(true);
+    setSearchError(null);
+    setDiscoveredUrl(null);
+    try {
+      const result = await dataLakeApi.agent.ingestion.discover({ query: searchQuery.trim() });
+      if (result.found) {
+        setDiscoveredUrl({ url: result.url, title: result.title });
+        setApiUrl(result.url);
+      } else {
+        setSearchError(`Couldn't find a spec for "${searchQuery}". Enter the URL manually.`);
+        setUrlMode('manual');
+      }
+    } catch (err) {
+      setSearchError(err.message || 'Search failed. Enter the URL manually.');
+      setUrlMode('manual');
+    } finally {
+      setIsSearching(false);
+    }
+  }, [searchQuery]);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -228,7 +257,10 @@ export default function AiPipeline() {
 
   const runFullPipeline = async () => {
     // Validate
-    if (!apiUrl.trim()) { setError('API URL is required'); return; }
+    if (!apiUrl.trim()) {
+      setError(urlMode === 'search' ? 'Search for an API first, or switch to "Enter URL"' : 'API URL is required');
+      return;
+    }
     if (!interests.trim()) { setError('At least one interest is required'); return; }
     if (!domain.trim()) { setError('Domain is required'); return; }
 
@@ -383,12 +415,96 @@ export default function AiPipeline() {
                 <Globe className="w-3.5 h-3.5 inline mr-1" />
                 API URL (OpenAPI / Swagger)
               </SketchyLabel>
-              <SketchyInput
-                placeholder="https://swapi.dev/api/"
-                value={apiUrl}
-                onChange={(e) => { setApiUrl(e.target.value); setError(null); }}
-                disabled={isRunning}
-              />
+
+              {/* Mode toggle */}
+              <div className="flex gap-1 p-1 bg-gray-100 rounded-xl border-2 border-gray-200 mb-2">
+                {[
+                  { value: 'search', label: 'Find API' },
+                  { value: 'manual', label: 'Enter URL' },
+                ].map(({ value, label }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => {
+                      setUrlMode(value);
+                      if (value === 'search') {
+                        setDiscoveredUrl(null);
+                        setApiUrl('');
+                        setSearchError(null);
+                      }
+                    }}
+                    disabled={isRunning}
+                    className={cn(
+                      'flex-1 py-1.5 text-xs font-bold rounded-lg transition-all',
+                      value === urlMode
+                        ? 'bg-white shadow text-gray-900 border border-gray-200'
+                        : 'text-gray-500 hover:text-gray-700',
+                    )}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Search mode — input + button */}
+              {urlMode === 'search' && !discoveredUrl && (
+                <div className="flex gap-2">
+                  <SketchyInput
+                    placeholder="Ex: Stripe, PokeAPI, IBGE..."
+                    value={searchQuery}
+                    onChange={(e) => { setSearchQuery(e.target.value); setSearchError(null); }}
+                    onKeyDown={(e) => e.key === 'Enter' && !isSearching && handleDiscover()}
+                    disabled={isRunning || isSearching}
+                    className="flex-1"
+                  />
+                  <SketchyButton
+                    type="button"
+                    onClick={handleDiscover}
+                    disabled={isRunning || isSearching || !searchQuery.trim()}
+                    variant="dark"
+                    size="sm"
+                    className="shrink-0"
+                  >
+                    {isSearching
+                      ? <Loader2 className="w-4 h-4 animate-spin" />
+                      : <Wand2 className="w-4 h-4" />}
+                  </SketchyButton>
+                </div>
+              )}
+
+              {/* Search mode — discovered result */}
+              {urlMode === 'search' && discoveredUrl && (
+                <div className="flex items-center gap-2 p-2.5 bg-emerald-50 rounded-xl border-2 border-emerald-200">
+                  <CheckCircle2 className="w-4 h-4 text-emerald-600 shrink-0" />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-xs font-bold text-emerald-800 truncate">{discoveredUrl.title}</p>
+                    <p className="text-xs text-emerald-600 truncate font-mono">{discoveredUrl.url}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => { setDiscoveredUrl(null); setApiUrl(''); setSearchError(null); }}
+                    disabled={isRunning}
+                    className="text-xs text-emerald-600 hover:text-emerald-800 font-bold shrink-0 underline"
+                  >
+                    change
+                  </button>
+                </div>
+              )}
+
+              {/* Manual mode */}
+              {urlMode === 'manual' && (
+                <SketchyInput
+                  placeholder="https://swapi.dev/api/"
+                  value={apiUrl}
+                  onChange={(e) => { setApiUrl(e.target.value); setError(null); }}
+                  disabled={isRunning}
+                />
+              )}
+
+              {/* Search error */}
+              {searchError && (
+                <p className="text-xs text-amber-600 mt-1 font-medium">{searchError}</p>
+              )}
             </div>
             <div>
               <SketchyLabel>
@@ -616,6 +732,11 @@ export default function AiPipeline() {
                   setOauth2Username('');
                   setOauth2Password('');
                   setBaseUrl('');
+                  setApiUrl('');
+                  setUrlMode('search');
+                  setSearchQuery('');
+                  setDiscoveredUrl(null);
+                  setSearchError(null);
                 }}
               >
                 Run Another

--- a/frontend/src/components/ai/AiPipeline.jsx
+++ b/frontend/src/components/ai/AiPipeline.jsx
@@ -411,39 +411,41 @@ export default function AiPipeline() {
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <SketchyLabel>
-                <Globe className="w-3.5 h-3.5 inline mr-1" />
-                API URL (OpenAPI / Swagger)
-              </SketchyLabel>
+              <div className="flex items-center justify-between mb-1.5">
+                <SketchyLabel className="mb-0">
+                  <Globe className="w-3.5 h-3.5 inline mr-1" />
+                  API URL (OpenAPI / Swagger)
+                </SketchyLabel>
 
-              {/* Mode toggle */}
-              <div className="flex gap-1 p-1 bg-gray-100 rounded-xl border-2 border-gray-200 mb-2">
-                {[
-                  { value: 'search', label: 'Find API' },
-                  { value: 'manual', label: 'Enter URL' },
-                ].map(({ value, label }) => (
-                  <button
-                    key={value}
-                    type="button"
-                    onClick={() => {
-                      setUrlMode(value);
-                      if (value === 'search') {
-                        setDiscoveredUrl(null);
-                        setApiUrl('');
-                        setSearchError(null);
-                      }
-                    }}
-                    disabled={isRunning}
-                    className={cn(
-                      'flex-1 py-1.5 text-xs font-bold rounded-lg transition-all',
-                      value === urlMode
-                        ? 'bg-white shadow text-gray-900 border border-gray-200'
-                        : 'text-gray-500 hover:text-gray-700',
-                    )}
-                  >
-                    {label}
-                  </button>
-                ))}
+                {/* Mode toggle — inline, compact */}
+                <div className="flex gap-0.5 p-0.5 bg-gray-100 rounded-lg border border-gray-200">
+                  {[
+                    { value: 'search', label: 'Find API' },
+                    { value: 'manual', label: 'Enter URL' },
+                  ].map(({ value, label }) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => {
+                        setUrlMode(value);
+                        if (value === 'search') {
+                          setDiscoveredUrl(null);
+                          setApiUrl('');
+                          setSearchError(null);
+                        }
+                      }}
+                      disabled={isRunning}
+                      className={cn(
+                        'px-2 py-0.5 text-[10px] font-bold rounded-md transition-all leading-tight',
+                        value === urlMode
+                          ? 'bg-white shadow-sm text-gray-900 border border-gray-200'
+                          : 'text-gray-400 hover:text-gray-600',
+                      )}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
               </div>
 
               {/* Search mode — input + button */}

--- a/lambdas/chat_api/.dockerignore
+++ b/lambdas/chat_api/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/ingestion_agent/.dockerignore
+++ b/lambdas/ingestion_agent/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/ingestion_agent/Dockerfile
+++ b/lambdas/ingestion_agent/Dockerfile
@@ -1,11 +1,9 @@
 # Use Python 3.12 Lambda image
 FROM public.ecr.aws/lambda/python:3.12
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-
 # Install dependencies
 COPY requirements.txt .
-RUN uv pip install --system --no-build -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the main Lambda handler
 COPY main.py .

--- a/lambdas/ingestion_agent/agents/ingestion_agent/agent.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/agent.py
@@ -220,6 +220,16 @@ async def _run_analysis(
         .deduplicate_by_resource_name()
     )
 
+    if not plan.endpoints:
+        raise ValueError(
+            "No ingestible endpoints found in this API spec. "
+            "Data lake ingestion requires GET endpoints that return collections of records. "
+            "This API may be a utility/processing API (e.g., JSON formatter, validator, "
+            "converter) with no stored data to ingest, or all its endpoints are mutations "
+            "(POST/PUT/PATCH/DELETE) or require path parameters (detail endpoints). "
+            "Only parameterless GET collection endpoints can be ingested."
+        )
+
     logger.info(
         "Plan generated: %s with %d endpoints",
         plan.api_name,

--- a/lambdas/ingestion_agent/agents/ingestion_agent/agent.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/agent.py
@@ -79,6 +79,38 @@ async def _fetch_docs_page(url: str, max_chars: int = 8000) -> str:
     return text
 
 
+async def _probe_spec_url(url: str, token: str | None = None) -> dict | None:
+    """
+    Fetch *url* and return the parsed spec dict if it looks like JSON/YAML.
+
+    Unlike _fetch_openapi_spec, this never recurses into HTML pages — it
+    returns None for anything that isn't parseable as a spec dict.
+    Used as a fallback probe when the main HTML parser can't find a spec URL.
+    """
+    headers = {"Accept": "application/json, application/yaml, */*"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        async with httpx.AsyncClient(follow_redirects=True, timeout=10.0) as client:
+            resp = await client.get(url, headers=headers)
+            if resp.status_code != 200:
+                return None
+            content_type = resp.headers.get("content-type", "")
+            if "html" in content_type:
+                return None
+            if "yaml" in content_type or url.lower().endswith((".yaml", ".yml")):
+                import yaml
+                data = yaml.safe_load(resp.text)
+                return data if isinstance(data, dict) else None
+            try:
+                data = resp.json()
+                return data if isinstance(data, dict) else None
+            except Exception:
+                return None
+    except Exception:
+        return None
+
+
 async def _fetch_openapi_spec(url: str, token: str | None = None) -> dict:
     """
     Fetch and parse an OpenAPI spec from a URL.
@@ -87,6 +119,12 @@ async def _fetch_openapi_spec(url: str, token: str | None = None) -> dict:
     When the URL returns a Swagger UI or Redoc HTML page, the function
     automatically detects and follows the embedded spec URL instead of
     raising an error.
+
+    Fallback for legacy/dynamic Swagger pages (e.g. Projuris ADV): when the
+    HTML page cannot be parsed for a literal spec URL (the URL is computed via
+    JavaScript at runtime), the function probes well-known spec paths on the
+    same host (e.g. /v3/api-docs, /v2/api-docs, /swagger.json).
+
     Raises ValueError with a clear message if the URL does not return
     a valid OpenAPI/Swagger spec and no spec URL can be detected.
     """
@@ -107,6 +145,36 @@ async def _fetch_openapi_spec(url: str, token: str | None = None) -> dict:
             spec_url = extract_swagger_spec_url(body, url)
             if spec_url:
                 return await _fetch_openapi_spec(spec_url, token)
+
+            # Fallback: some Swagger UIs (legacy Springfox, old swagger-ui-dist)
+            # compute the spec URL dynamically in JavaScript — there's no literal
+            # URL string in the HTML to parse.  Probe well-known paths on the
+            # same host before giving up.
+            from urllib.parse import urlparse
+            parsed = urlparse(url)
+            host = f"{parsed.scheme}://{parsed.netloc}"
+            # Also probe relative to the page's directory (e.g. /ui/swagger.json)
+            page_dir = url[: url.rfind("/")] if url.rfind("/") > len(host) else host
+            fallback_candidates = [
+                host + "/v3/api-docs",           # Springdoc (Spring Boot 3)
+                host + "/v2/api-docs",           # Springfox (Spring Boot 2)
+                host + "/api-docs",
+                host + "/openapi.json",
+                host + "/swagger.json",
+                host + "/openapi.yaml",
+                page_dir + "/swagger.json",      # relative to page dir
+            ]
+            for candidate in fallback_candidates:
+                if candidate == url:
+                    continue
+                spec = await _probe_spec_url(candidate, token)
+                if spec:
+                    logger.info(
+                        "HTML page at %s — found spec via host probe at %s",
+                        url, candidate,
+                    )
+                    return spec
+
             raise ValueError(
                 f"The URL '{url}' returned an HTML page, not an OpenAPI/Swagger spec. "
                 f"Please provide a direct URL to the JSON or YAML spec file "

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -1,8 +1,14 @@
-"""OpenAPI URL discovery via Amazon Nova Web Grounding.
+"""OpenAPI URL discovery via DuckDuckGo search + Claude Sonnet reasoning.
 
 Given a free-text API name (e.g. "Projuris", "Star Wars"), this module:
-1. Asks Nova 2 Lite (with nova_grounding system tool) to find the spec URL.
-2. Probes the returned URL (or candidate host) to verify it's a real spec.
+1. Searches DuckDuckGo (no API key required) for the API's docs/spec URL.
+2. Uses Claude Sonnet on Bedrock to reason about the search results and pick
+   the most likely spec or documentation URL.
+3. Probes the chosen URL (and its host) to verify it returns a valid spec.
+
+This replaces the previous Nova Web Grounding approach, which was exclusive
+to Amazon Nova 2 models and consistently returned marketing homepages instead
+of actual API documentation subdomains.
 """
 
 from __future__ import annotations
@@ -12,6 +18,7 @@ import json
 import logging
 import os
 import re
+import urllib.parse
 from urllib.parse import urlparse
 
 import boto3
@@ -47,6 +54,14 @@ _SPEC_PATHS = [
 ]
 
 _HTTP_TIMEOUT = 8.0
+
+_DDG_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0"
+    ),
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "en-US,en;q=0.5",
+}
 
 
 def _is_openapi_spec(data: object) -> bool:
@@ -108,7 +123,7 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
             # Fallback: legacy Swagger UIs (e.g. Springfox / swagger-ui-dist)
             # compute the spec URL dynamically via JavaScript — no literal URL
             # in the HTML to parse.  Probe well-known spec paths on the same
-            # host before giving up (mirrors _fetch_openapi_spec behaviour).
+            # host before giving up.
             from urllib.parse import urlparse as _urlparse
             _parsed = _urlparse(final_url)
             _host = f"{_parsed.scheme}://{_parsed.netloc}"
@@ -132,13 +147,86 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
 
 
 # ---------------------------------------------------------------------------
-# Nova Web Grounding
+# DuckDuckGo search (no API key)
+# ---------------------------------------------------------------------------
+
+async def _duckduckgo_search(query: str, max_results: int = 8) -> list[dict]:
+    """
+    Search DuckDuckGo for ``query`` and return the top results as
+    ``[{"url": str, "title": str, "snippet": str}]``.
+
+    Uses the DuckDuckGo HTML endpoint — no API key needed.
+    Result URLs are extracted from ``uddg=<encoded-url>`` href params.
+    """
+    search_query = f"{query} openapi swagger api documentation"
+    params = urllib.parse.urlencode({"q": search_query})
+
+    try:
+        async with httpx.AsyncClient(
+            headers=_DDG_HEADERS,
+            follow_redirects=True,
+            timeout=15.0,
+        ) as client:
+            resp = await client.get(f"https://html.duckduckgo.com/html/?{params}")
+            if resp.status_code != 200:
+                logger.warning(
+                    "[discovery] DuckDuckGo returned HTTP %s", resp.status_code
+                )
+                return []
+
+            html = resp.text
+
+            # Extract (encoded_url, title) pairs from result__a anchors
+            title_re = re.compile(
+                r'<a[^>]+class="result__a"[^>]+href="[^"]*uddg=([^&"]+)[^"]*"[^>]*>'
+                r'(.*?)</a>',
+                re.IGNORECASE | re.DOTALL,
+            )
+            # Extract snippets from result__snippet anchors
+            snippet_re = re.compile(
+                r'<a[^>]+class="result__snippet"[^>]*>(.*?)</a>',
+                re.IGNORECASE | re.DOTALL,
+            )
+
+            title_matches = title_re.findall(html)
+            snippet_matches = [
+                re.sub(r"<[^>]+>", "", s).strip()
+                for s in snippet_re.findall(html)
+            ]
+
+            results: list[dict] = []
+            for i, (encoded_url, raw_title) in enumerate(title_matches):
+                if len(results) >= max_results:
+                    break
+                try:
+                    url = urllib.parse.unquote(encoded_url)
+                    if not url.startswith("http"):
+                        continue
+                    title = re.sub(r"<[^>]+>", "", raw_title).strip()
+                    snippet = snippet_matches[i] if i < len(snippet_matches) else ""
+                    results.append({"url": url, "title": title, "snippet": snippet})
+                except Exception:
+                    pass
+
+            logger.info(
+                "[discovery] DuckDuckGo returned %d results for '%s': %s",
+                len(results), query, [r["url"] for r in results],
+            )
+            return results
+
+    except Exception as exc:
+        logger.warning("[discovery] DuckDuckGo search failed for '%s': %s", query, exc)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Claude Sonnet reasoning — picks the best URL from search results
 # ---------------------------------------------------------------------------
 
 class _DiscoveryResult(BaseModel):
     spec_url: str | None = Field(
         default=None,
-        description="Direct URL of the OpenAPI spec file or API index root.",
+        description="Direct URL of the OpenAPI spec file, API index, or Swagger UI page.",
     )
     title: str | None = Field(
         default=None,
@@ -150,43 +238,62 @@ class _DiscoveryResult(BaseModel):
     )
 
 
-_DISCOVERY_PROMPT = """\
-Search the web for the OpenAPI/Swagger spec URL of the '{query}' API.
+_CLAUDE_PROMPT = """\
+You are helping find the OpenAPI/Swagger documentation URL for the '{query}' API.
 
-Look for:
-1. Direct spec files: swagger.json, openapi.json, /v3/api-docs, /api-docs
-2. API index JSON (e.g. SWAPI: https://swapi.dev/api/ returns {{"people":"url",...}})
-3. Swagger UI or Redoc HTML documentation pages (e.g. /swagger-ui.html, /ui/index.html, /docs)
-4. Developer or API portal pages that reference or link to the spec
+Here are web search results:
+{results_json}
 
-Return ONLY this JSON object — no markdown, no explanation:
+Analyze these results and identify the URL most likely to be:
+1. A direct OpenAPI spec file (swagger.json, openapi.json, /v3/api-docs, /api-docs)
+2. A Swagger UI or Redoc HTML documentation page (/swagger-ui.html, /ui/index.html, /docs)
+3. An API index endpoint that returns JSON with resource URLs
+
+Prefer:
+- Subdomains like docs., api., developer., swagger.
+- Paths containing api-docs, openapi, swagger, developer in the URL
+
+Avoid:
+- Marketing homepages (e.g. www.company.com with no API path)
+- Blog posts or tutorials about the API
+
+Return ONLY this JSON — no markdown, no explanation:
 {{"spec_url": "https://...", "title": "API Name", "candidate_host": null}}
 
 Rules:
-- spec_url: URL to the spec file, API index root, OR Swagger/Redoc HTML docs page (null if not found)
-- title: human-readable API name
-- candidate_host: base URL (scheme://host) to probe with common spec paths when spec_url is null
+- spec_url: the best candidate URL found (null if nothing looks like API docs)
+- title: human-readable API name from the search results
+- candidate_host: scheme://host to probe with common spec paths when spec_url is null
 """
 
 
-def _nova_grounding_sync(query: str) -> _DiscoveryResult:
-    """Call Nova Web Grounding synchronously (runs in thread pool)."""
-    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-    model_id = os.environ.get("INGESTION_AGENT_MODEL_ID", "us.amazon.nova-2-lite-v1:0")
+def _claude_pick_url_sync(query: str, results: list[dict]) -> _DiscoveryResult:
+    """
+    Use Claude Sonnet on Bedrock to reason about DuckDuckGo search results
+    and return the most likely OpenAPI spec or documentation URL.
 
-    client = boto3.client(
-        "bedrock-runtime",
-        region_name=region,
-        config=Config(read_timeout=60, connect_timeout=10),
+    Runs synchronously — call via asyncio.to_thread from async context.
+    """
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    model_id = os.environ.get(
+        "DISCOVERY_MODEL_ID",
+        "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
     )
 
-    response = client.converse(
+    bedrock = boto3.client(
+        "bedrock-runtime",
+        region_name=region,
+        config=Config(read_timeout=30, connect_timeout=10),
+    )
+
+    prompt = _CLAUDE_PROMPT.format(
+        query=query,
+        results_json=json.dumps(results, ensure_ascii=False, indent=2),
+    )
+
+    response = bedrock.converse(
         modelId=model_id,
-        messages=[{
-            "role": "user",
-            "content": [{"text": _DISCOVERY_PROMPT.format(query=query)}],
-        }],
-        toolConfig={"tools": [{"systemTool": {"name": "nova_grounding"}}]},
+        messages=[{"role": "user", "content": [{"text": prompt}]}],
     )
 
     text_parts = [
@@ -195,18 +302,18 @@ def _nova_grounding_sync(query: str) -> _DiscoveryResult:
         if "text" in c
     ]
     raw_text = "\n".join(text_parts)
-    logger.info("[discovery] Nova Grounding raw for '%s': %.400s", query, raw_text)
+    logger.info("[discovery] Claude reasoning for '%s': %.400s", query, raw_text)
 
     match = re.search(r'\{[^{}]*"spec_url"[^{}]*\}', raw_text, re.DOTALL)
     if match:
         result = _DiscoveryResult.model_validate(json.loads(match.group()))
         logger.info(
-            "[discovery] Nova Grounding result: spec_url=%s candidate=%s",
+            "[discovery] Claude picked: spec_url=%s candidate=%s",
             result.spec_url, result.candidate_host,
         )
         return result
 
-    logger.warning("[discovery] Nova Grounding returned no parseable JSON for '%s'", query)
+    logger.warning("[discovery] Claude returned no parseable JSON for '%s'", query)
     return _DiscoveryResult()
 
 
@@ -227,23 +334,32 @@ async def discover_openapi_url(query: str) -> dict | None:
     """
     Discover the OpenAPI/Swagger spec URL for a free-text *query*.
 
-    Uses Amazon Nova Web Grounding (nova_grounding system tool) to search
-    the web natively — no external API keys, no DuckDuckGo rate limits.
+    Uses DuckDuckGo (no API key) for web search and Claude Sonnet on Bedrock
+    to reason about which result is the real API documentation URL.
 
     Returns ``{"url": str, "title": str}`` on success, ``None`` otherwise.
     """
-    try:
-        discovery = await asyncio.to_thread(_nova_grounding_sync, query)
-    except Exception as exc:
-        logger.error("[discovery] Nova Grounding failed for '%s': %s", query, exc)
+    # Step 1: Search DuckDuckGo
+    results = await _duckduckgo_search(query)
+
+    if not results:
+        logger.info("[discovery] No DuckDuckGo results for '%s'", query)
         return None
+
+    # Step 2: Claude reasons about which URL is the spec/docs
+    try:
+        discovery = await asyncio.to_thread(_claude_pick_url_sync, query, results)
+    except Exception as exc:
+        logger.error("[discovery] Claude reasoning failed for '%s': %s", query, exc)
+        # Fallback: treat all DDG results as candidates
+        discovery = _DiscoveryResult()
 
     async with httpx.AsyncClient(
         headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},
         follow_redirects=True,
     ) as client:
 
-        # Case A: grounding returned a direct spec URL → verify it
+        # Case A: Claude returned a specific spec/docs URL → verify it
         if discovery.spec_url:
             result = await _probe_url(client, discovery.spec_url)
             if result:
@@ -258,18 +374,40 @@ async def discover_openapi_url(query: str) -> dict | None:
                 for path in _SPEC_PATHS:
                     result = await _probe_url(client, host + path)
                     if result:
-                        logger.info("[discovery] Found spec at %s (path probe)", result["url"])
-                        return {"url": result["url"], "title": _extract_title(result["data"], query)}
+                        logger.info(
+                            "[discovery] Found spec at %s (path probe on Claude pick)",
+                            result["url"],
+                        )
+                        return {
+                            "url": result["url"],
+                            "title": _extract_title(result["data"], query),
+                        }
 
-        # Case B: only a candidate host → probe common spec paths
+        # Case B: Claude returned only a candidate host → probe common paths
         if discovery.candidate_host:
             host = discovery.candidate_host.rstrip("/")
             logger.info("[discovery] Probing candidate host: %s", host)
             for path in _SPEC_PATHS:
                 result = await _probe_url(client, host + path)
                 if result:
-                    logger.info("[discovery] Found spec at %s", result["url"])
-                    return {"url": result["url"], "title": _extract_title(result["data"], query)}
+                    return {
+                        "url": result["url"],
+                        "title": _extract_title(result["data"], query),
+                    }
+
+        # Case C: Claude found nothing useful → probe all DDG result URLs directly
+        logger.info(
+            "[discovery] Claude found no URL for '%s' — probing all DDG results",
+            query,
+        )
+        for ddg_result in results:
+            result = await _probe_url(client, ddg_result["url"])
+            if result:
+                title = _extract_title(result["data"], query) or ddg_result.get("title", query)
+                logger.info(
+                    "[discovery] Found spec at %s (DDG fallback)", result["url"]
+                )
+                return {"url": result["url"], "title": title}
 
     logger.info("[discovery] No spec found for query: %s", query)
     return None

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -81,10 +81,17 @@ def _is_api_index(data: object) -> bool:
     )
 
 
-async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
+async def _probe_url(
+    client: httpx.AsyncClient, url: str, _depth: int = 0
+) -> dict | None:
     """
     Fetch *url* and return ``{"url": str, "data": dict}`` if it is a valid
     OpenAPI spec or API index. Returns ``None`` otherwise.
+
+    *_depth* is internal — callers should never pass it.  It prevents
+    infinite recursion when HTML pages return other HTML pages:
+    - depth 0: full handling (JSON / YAML / HTML with spec extraction)
+    - depth 1: JSON / YAML only — HTML is silently ignored
     """
     from agents.ingestion_agent.spec_parser import extract_swagger_spec_url
 
@@ -113,10 +120,13 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
             except Exception:
                 pass
 
-        if "html" in content_type:
+        # HTML handling only at depth 0 — recursive calls must never re-enter
+        # this block, otherwise a host that returns HTML for every path causes
+        # unbounded recursion until Python's stack limit is hit (~1000 frames).
+        if "html" in content_type and _depth == 0:
             spec_url = extract_swagger_spec_url(resp.text, url)
             if spec_url:
-                inner = await _probe_url(client, spec_url)
+                inner = await _probe_url(client, spec_url, _depth=1)
                 if inner:
                     return inner
 
@@ -132,7 +142,7 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
                 _candidate = _host + _path
                 if _candidate == url:
                     continue
-                _inner = await _probe_url(client, _candidate)
+                _inner = await _probe_url(client, _candidate, _depth=1)
                 if _inner:
                     logger.info(
                         "[discovery] HTML at %s — spec found via host probe at %s",

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -171,12 +171,14 @@ def _llm_select_candidates_sync(query: str, results: list[dict]) -> list[str]:
             "API and a list of web search results, identify which URLs are most likely to be "
             "the OpenAPI/Swagger spec file or official API documentation for that specific API.\n\n"
             "Rules:\n"
-            "- ONLY return URLs genuinely related to the queried API — not generic tools, "
-            "tutorials, or unrelated APIs that happened to appear in results.\n"
-            "- If none of the results are about the queried API, return an empty list.\n"
-            "- Prefer direct spec file URLs (.json, .yaml) over docs pages.\n"
+            "- Return the most likely candidate URLs or base domains even if you are not certain "
+            "a spec exists — the system will probe common paths (/openapi.json, /swagger.json, etc.) "
+            "automatically, so you don't need to confirm a spec is present.\n"
+            "- Prefer direct spec file URLs (.json, .yaml) over docs pages, but any domain that "
+            "plausibly hosts the API is a valid candidate.\n"
             "- Return at most 3 candidates, ordered by confidence (best first).\n"
-            "- Be conservative: a wrong API is worse than returning nothing.\n\n"
+            "- Only return an empty list if ALL results are clearly about a completely different "
+            "product or topic (e.g. query is 'Projuris' but results are all about 'Stripe').\n\n"
             'Respond with ONLY a JSON object: {"candidate_urls": ["url1", "url2"]}'
         ),
     )
@@ -254,8 +256,22 @@ async def discover_openapi_url(query: str) -> dict | None:
     # LLM filters search results to only relevant candidates
     candidate_urls = await _llm_select_candidates(query, all_results)
     if not candidate_urls:
-        logger.info("[discovery] LLM found no relevant candidates for: %s", query)
-        return None
+        # Fallback: keyword match on domain/title — the probe will verify if a spec exists
+        keyword = query.lower().split()[0]
+        candidate_urls = [
+            r["href"]
+            for r in all_results
+            if keyword in r.get("href", "").lower() or keyword in r.get("title", "").lower()
+            if r.get("href")
+        ][:3]
+        if candidate_urls:
+            logger.info(
+                "[discovery] LLM returned empty — keyword fallback found %d candidate(s): %s",
+                len(candidate_urls), candidate_urls,
+            )
+        else:
+            logger.info("[discovery] No candidates found for: %s", query)
+            return None
 
     logger.info("[discovery] Probing %d candidate(s): %s", len(candidate_urls), candidate_urls)
 

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -55,6 +55,37 @@ _SPEC_PATHS = [
 
 _HTTP_TIMEOUT = 8.0
 
+# Domains that are API tooling / documentation platforms, not actual API providers.
+# Excluding them prevents the fallback prober from wasting requests on e.g.
+# SmartBear (owners of Swagger), Stoplight, Postman, etc.
+_TOOLING_DOMAINS = frozenset({
+    "smartbear.com",
+    "swagger.io",
+    "openapis.org",
+    "stoplight.io",
+    "readme.io",
+    "readme.com",
+    "postman.com",
+    "apiary.io",
+    "restlet.com",
+    "apigee.com",
+    "redoc.ly",
+    "redocly.com",
+    "rapidapi.com",
+    "apidog.com",
+    "insomnia.rest",
+})
+
+
+def _is_tooling_url(url: str) -> bool:
+    """Return True if *url* belongs to a generic API tooling/platform domain."""
+    try:
+        host = urlparse(url).netloc.lower().lstrip("www.")
+        return any(host == d or host.endswith("." + d) for d in _TOOLING_DOMAINS)
+    except Exception:
+        return False
+
+
 _DDG_HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0"
@@ -168,7 +199,9 @@ async def _duckduckgo_search(query: str, max_results: int = 8) -> list[dict]:
     Uses the DuckDuckGo HTML endpoint — no API key needed.
     Result URLs are extracted from ``uddg=<encoded-url>`` href params.
     """
-    search_query = f"{query} openapi swagger api documentation"
+    # Avoid "swagger" — it consistently pollutes results with SmartBear/Swagger.io
+    # which are API tooling sites, not the API we're looking for.
+    search_query = f"{query} REST API documentation openapi"
     params = urllib.parse.urlencode({"q": search_query})
 
     try:
@@ -211,6 +244,9 @@ async def _duckduckgo_search(query: str, max_results: int = 8) -> list[dict]:
                 try:
                     url = urllib.parse.unquote(encoded_url)
                     if not url.startswith("http"):
+                        continue
+                    if _is_tooling_url(url):
+                        logger.debug("[discovery] DDG skip tooling domain: %s", url)
                         continue
                     title = re.sub(r"<[^>]+>", "", raw_title).strip()
                     snippet = snippet_matches[i] if i < len(snippet_matches) else ""

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -1,0 +1,202 @@
+"""OpenAPI URL discovery via web search.
+
+Given a free-text API name (e.g. "Stripe", "PokeAPI"), this module searches
+DuckDuckGo for candidate OpenAPI/Swagger specs, probes common URL patterns on
+each host, validates each candidate, and returns the single best result — or
+None if no valid spec is found.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from urllib.parse import urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Common OpenAPI spec paths to probe on each candidate host
+_SPEC_PATHS = [
+    "/openapi.json",
+    "/openapi.yaml",
+    "/swagger.json",
+    "/swagger.yaml",
+    "/api-docs",
+    "/v3/api-docs",
+    "/v2/api-docs",
+    "/api/openapi.json",
+    "/api/swagger.json",
+    "/docs/openapi.json",
+    "/api/v1/openapi.json",
+    "/api/v2/openapi.json",
+    "/api/v3/openapi.json",
+    "/swagger/v1/swagger.json",
+    "/swagger/v2/swagger.json",
+]
+
+# URL fragments that strongly suggest an OpenAPI spec path
+_SPEC_FRAGMENTS = ("/openapi", "/swagger", "/api-docs")
+
+_HTTP_TIMEOUT = 6.0  # seconds per probe
+
+
+def _is_openapi_spec(data: object) -> bool:
+    return (
+        isinstance(data, dict)
+        and ("openapi" in data or "swagger" in data)
+        and "paths" in data
+    )
+
+
+def _is_api_index(data: object) -> bool:
+    """True for simple API index dicts (e.g. SWAPI, Rick & Morty root)."""
+    return (
+        isinstance(data, dict)
+        and bool(data)
+        and all(isinstance(v, str) and v.startswith("http") for v in data.values())
+    )
+
+
+async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
+    """
+    Fetch *url* and return ``{"url": str, "data": dict}`` if it is a valid
+    OpenAPI spec or API index. Returns ``None`` otherwise.
+    """
+    from agents.ingestion_agent.spec_parser import extract_swagger_spec_url
+
+    try:
+        resp = await client.get(url, timeout=_HTTP_TIMEOUT, follow_redirects=True)
+        if resp.status_code != 200:
+            return None
+
+        content_type = resp.headers.get("content-type", "")
+        final_url = str(resp.url)
+
+        # JSON
+        if "json" in content_type or url.lower().endswith((".json",)):
+            try:
+                data = resp.json()
+                if _is_openapi_spec(data) or _is_api_index(data):
+                    return {"url": final_url, "data": data}
+            except Exception:
+                pass
+
+        # YAML
+        if "yaml" in content_type or url.lower().endswith((".yaml", ".yml")):
+            try:
+                import yaml
+
+                data = yaml.safe_load(resp.text)
+                if _is_openapi_spec(data) or _is_api_index(data):
+                    return {"url": final_url, "data": data}
+            except Exception:
+                pass
+
+        # HTML — look for embedded Swagger UI / Redoc spec URL (one level deep)
+        if "html" in content_type:
+            spec_url = extract_swagger_spec_url(resp.text, url)
+            if spec_url:
+                inner = await _probe_url(client, spec_url)
+                if inner:
+                    return inner
+
+    except Exception as exc:
+        logger.debug("Probe failed for %s: %s", url, exc)
+
+    return None
+
+
+def _search_ddg(query: str) -> list[dict]:
+    """Synchronous DuckDuckGo search — runs in a thread executor."""
+    from duckduckgo_search import DDGS
+
+    all_results: list[dict] = []
+    ddgs = DDGS()
+    search_queries = [
+        f"{query} openapi swagger json spec",
+        f"{query} swagger.json OR openapi.json",
+    ]
+    for sq in search_queries:
+        try:
+            results = ddgs.text(sq, max_results=8)
+            all_results.extend(results or [])
+        except Exception as exc:
+            logger.warning("DDG search failed for '%s': %s", sq, exc)
+    return all_results
+
+
+def _candidate_hosts(results: list[dict]) -> list[str]:
+    """Extract unique base hosts from search results, preserving order."""
+    seen: set[str] = set()
+    hosts: list[str] = []
+    for r in results:
+        href = r.get("href", "")
+        if not href:
+            continue
+        try:
+            parsed = urlparse(href)
+            host = f"{parsed.scheme}://{parsed.netloc}"
+            if host not in seen:
+                seen.add(host)
+                hosts.append(host)
+        except Exception:
+            continue
+    return hosts
+
+
+def _extract_title(spec: dict, fallback: str) -> str:
+    info = spec.get("info", {})
+    title = info.get("title", "")
+    version = info.get("version", "")
+    if title:
+        return f"{title} {version}".strip()
+    return fallback
+
+
+async def discover_openapi_url(query: str) -> dict | None:
+    """
+    Discover the OpenAPI/Swagger spec URL for a free-text *query*.
+
+    Strategy:
+    1. Search DuckDuckGo for ``"{query} openapi swagger json spec"``.
+    2. Probe direct URLs from results that look like spec files.
+    3. Probe common spec paths on the top candidate hosts.
+
+    Returns ``{"url": str, "title": str}`` on success, ``None`` otherwise.
+    """
+    all_results = await asyncio.to_thread(_search_ddg, query)
+    if not all_results:
+        logger.info("No DDG results for query: %s", query)
+        return None
+
+    async with httpx.AsyncClient(
+        headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},
+        follow_redirects=True,
+    ) as client:
+        # --- Pass 1: probe direct URLs from search results that look like specs ---
+        for r in all_results:
+            href = r.get("href", "")
+            if not href:
+                continue
+            looks_like_spec = href.lower().endswith(
+                (".json", ".yaml", ".yml")
+            ) or any(frag in href for frag in _SPEC_FRAGMENTS)
+            if not looks_like_spec:
+                continue
+            result = await _probe_url(client, href)
+            if result:
+                logger.info("Discovered spec at %s (direct URL)", result["url"])
+                return {"url": result["url"], "title": _extract_title(result["data"], query)}
+
+        # --- Pass 2: probe common spec paths on top candidate hosts ---
+        hosts = _candidate_hosts(all_results)
+        for host in hosts[:5]:
+            for path in _SPEC_PATHS:
+                result = await _probe_url(client, host + path)
+                if result:
+                    logger.info("Discovered spec at %s (path probe)", result["url"])
+                    return {"url": result["url"], "title": _extract_title(result["data"], query)}
+
+    logger.info("No valid OpenAPI spec found for query: %s", query)
+    return None

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -105,6 +105,26 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
                 if inner:
                     return inner
 
+            # Fallback: legacy Swagger UIs (e.g. Springfox / swagger-ui-dist)
+            # compute the spec URL dynamically via JavaScript — no literal URL
+            # in the HTML to parse.  Probe well-known spec paths on the same
+            # host before giving up (mirrors _fetch_openapi_spec behaviour).
+            from urllib.parse import urlparse as _urlparse
+            _parsed = _urlparse(final_url)
+            _host = f"{_parsed.scheme}://{_parsed.netloc}"
+            for _path in ("/v3/api-docs", "/v2/api-docs", "/api-docs",
+                          "/openapi.json", "/swagger.json", "/openapi.yaml"):
+                _candidate = _host + _path
+                if _candidate == url:
+                    continue
+                _inner = await _probe_url(client, _candidate)
+                if _inner:
+                    logger.info(
+                        "[discovery] HTML at %s — spec found via host probe at %s",
+                        url, _candidate,
+                    )
+                    return _inner
+
     except Exception as exc:
         logger.warning("[discovery] Probe failed for %s: %s", url, exc)
 
@@ -136,15 +156,16 @@ Search the web for the OpenAPI/Swagger spec URL of the '{query}' API.
 Look for:
 1. Direct spec files: swagger.json, openapi.json, /v3/api-docs, /api-docs
 2. API index JSON (e.g. SWAPI: https://swapi.dev/api/ returns {{"people":"url",...}})
-3. Developer portal pages that link to the spec URL
+3. Swagger UI or Redoc HTML documentation pages (e.g. /swagger-ui.html, /ui/index.html, /docs)
+4. Developer or API portal pages that reference or link to the spec
 
 Return ONLY this JSON object — no markdown, no explanation:
 {{"spec_url": "https://...", "title": "API Name", "candidate_host": null}}
 
 Rules:
-- spec_url: direct URL to the spec file or API index root (null if not found)
+- spec_url: URL to the spec file, API index root, OR Swagger/Redoc HTML docs page (null if not found)
 - title: human-readable API name
-- candidate_host: base URL (scheme://host) to probe if spec_url is null
+- candidate_host: base URL (scheme://host) to probe with common spec paths when spec_url is null
 """
 
 

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -33,6 +33,12 @@ _SPEC_PATHS = [
     "/api/v3/openapi.json",
     "/swagger/v1/swagger.json",
     "/swagger/v2/swagger.json",
+    # API index roots (e.g. SWAPI, Rick & Morty) — no formal OpenAPI spec
+    "/api/",
+    "/api",
+    "/api/v1/",
+    "/api/v2/",
+    "/api/v3/",
 ]
 
 # URL fragments that strongly suggest an OpenAPI spec path
@@ -109,7 +115,7 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
 
 def _search_ddg(query: str) -> list[dict]:
     """Synchronous DuckDuckGo search — runs in a thread executor."""
-    from duckduckgo_search import DDGS
+    from ddgs import DDGS
 
     # Append "API" if the user didn't mention it, so generic terms like
     # "starwars" or "weather" target API docs instead of unrelated content.

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -111,11 +111,15 @@ def _search_ddg(query: str) -> list[dict]:
     """Synchronous DuckDuckGo search — runs in a thread executor."""
     from duckduckgo_search import DDGS
 
+    # Append "API" if the user didn't mention it, so generic terms like
+    # "starwars" or "weather" target API docs instead of unrelated content.
+    q = query if any(w in query.lower() for w in ("api", "swagger", "openapi")) else f"{query} API"
+
     all_results: list[dict] = []
     ddgs = DDGS()
     search_queries = [
-        f"{query} openapi swagger json spec",
-        f"{query} swagger.json OR openapi.json",
+        f"{q} openapi swagger json spec",
+        f"{q} swagger.json OR openapi.json",
     ]
     for sq in search_queries:
         try:

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -1,14 +1,8 @@
-"""OpenAPI URL discovery via DuckDuckGo search + Claude Sonnet reasoning.
+"""OpenAPI URL discovery via Amazon Nova Web Grounding.
 
 Given a free-text API name (e.g. "Projuris", "Star Wars"), this module:
-1. Searches DuckDuckGo (no API key required) for the API's docs/spec URL.
-2. Uses Claude Sonnet on Bedrock to reason about the search results and pick
-   the most likely spec or documentation URL.
-3. Probes the chosen URL (and its host) to verify it returns a valid spec.
-
-This replaces the previous Nova Web Grounding approach, which was exclusive
-to Amazon Nova 2 models and consistently returned marketing homepages instead
-of actual API documentation subdomains.
+1. Asks Nova 2 Lite (with nova_grounding system tool) to find the spec URL.
+2. Probes the returned URL (or candidate host) to verify it's a real spec.
 """
 
 from __future__ import annotations
@@ -18,7 +12,6 @@ import json
 import logging
 import os
 import re
-import urllib.parse
 from urllib.parse import urlparse
 
 import boto3
@@ -55,45 +48,6 @@ _SPEC_PATHS = [
 
 _HTTP_TIMEOUT = 8.0
 
-# Domains that are API tooling / documentation platforms, not actual API providers.
-# Excluding them prevents the fallback prober from wasting requests on e.g.
-# SmartBear (owners of Swagger), Stoplight, Postman, etc.
-_TOOLING_DOMAINS = frozenset({
-    "smartbear.com",
-    "swagger.io",
-    "openapis.org",
-    "stoplight.io",
-    "readme.io",
-    "readme.com",
-    "postman.com",
-    "apiary.io",
-    "restlet.com",
-    "apigee.com",
-    "redoc.ly",
-    "redocly.com",
-    "rapidapi.com",
-    "apidog.com",
-    "insomnia.rest",
-})
-
-
-def _is_tooling_url(url: str) -> bool:
-    """Return True if *url* belongs to a generic API tooling/platform domain."""
-    try:
-        host = urlparse(url).netloc.lower().lstrip("www.")
-        return any(host == d or host.endswith("." + d) for d in _TOOLING_DOMAINS)
-    except Exception:
-        return False
-
-
-_DDG_HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0"
-    ),
-    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-    "Accept-Language": "en-US,en;q=0.5",
-}
-
 
 def _is_openapi_spec(data: object) -> bool:
     return (
@@ -112,17 +66,10 @@ def _is_api_index(data: object) -> bool:
     )
 
 
-async def _probe_url(
-    client: httpx.AsyncClient, url: str, _depth: int = 0
-) -> dict | None:
+async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
     """
     Fetch *url* and return ``{"url": str, "data": dict}`` if it is a valid
     OpenAPI spec or API index. Returns ``None`` otherwise.
-
-    *_depth* is internal — callers should never pass it.  It prevents
-    infinite recursion when HTML pages return other HTML pages:
-    - depth 0: full handling (JSON / YAML / HTML with spec extraction)
-    - depth 1: JSON / YAML only — HTML is silently ignored
     """
     from agents.ingestion_agent.spec_parser import extract_swagger_spec_url
 
@@ -151,35 +98,12 @@ async def _probe_url(
             except Exception:
                 pass
 
-        # HTML handling only at depth 0 — recursive calls must never re-enter
-        # this block, otherwise a host that returns HTML for every path causes
-        # unbounded recursion until Python's stack limit is hit (~1000 frames).
-        if "html" in content_type and _depth == 0:
+        if "html" in content_type:
             spec_url = extract_swagger_spec_url(resp.text, url)
             if spec_url:
-                inner = await _probe_url(client, spec_url, _depth=1)
+                inner = await _probe_url(client, spec_url)
                 if inner:
                     return inner
-
-            # Fallback: legacy Swagger UIs (e.g. Springfox / swagger-ui-dist)
-            # compute the spec URL dynamically via JavaScript — no literal URL
-            # in the HTML to parse.  Probe well-known spec paths on the same
-            # host before giving up.
-            from urllib.parse import urlparse as _urlparse
-            _parsed = _urlparse(final_url)
-            _host = f"{_parsed.scheme}://{_parsed.netloc}"
-            for _path in ("/v3/api-docs", "/v2/api-docs", "/api-docs",
-                          "/openapi.json", "/swagger.json", "/openapi.yaml"):
-                _candidate = _host + _path
-                if _candidate == url:
-                    continue
-                _inner = await _probe_url(client, _candidate, _depth=1)
-                if _inner:
-                    logger.info(
-                        "[discovery] HTML at %s — spec found via host probe at %s",
-                        url, _candidate,
-                    )
-                    return _inner
 
     except Exception as exc:
         logger.warning("[discovery] Probe failed for %s: %s", url, exc)
@@ -188,98 +112,13 @@ async def _probe_url(
 
 
 # ---------------------------------------------------------------------------
-# DuckDuckGo search (no API key)
-# ---------------------------------------------------------------------------
-
-async def _duckduckgo_search(query: str, max_results: int = 8) -> list[dict]:
-    """
-    Search DuckDuckGo for ``query`` and return the top results as
-    ``[{"url": str, "title": str, "snippet": str}]``.
-
-    Uses the DuckDuckGo HTML endpoint — no API key needed.
-    Result URLs are extracted from ``uddg=<encoded-url>`` href params.
-    """
-    # "swagger" helps rank the actual Swagger UI page over the generic docs root
-    # (e.g. /ui/index.html vs just the domain). SmartBear/swagger.io are blocked
-    # by _TOOLING_DOMAINS so they won't pollute the results.
-    search_query = f"{query} REST API documentation openapi swagger"
-    params = urllib.parse.urlencode({"q": search_query})
-
-    try:
-        async with httpx.AsyncClient(
-            headers=_DDG_HEADERS,
-            follow_redirects=True,
-            timeout=15.0,
-        ) as client:
-            resp = await client.get(f"https://html.duckduckgo.com/html/?{params}")
-            if resp.status_code not in (200, 202):
-                logger.warning(
-                    "[discovery] DuckDuckGo returned HTTP %s", resp.status_code
-                )
-                return []
-
-            if resp.status_code == 202:
-                logger.warning(
-                    "[discovery] DuckDuckGo returned HTTP 202 (bot-check) — "
-                    "attempting to parse body anyway"
-                )
-
-            html = resp.text
-
-            # Extract (encoded_url, title) pairs from result__a anchors
-            title_re = re.compile(
-                r'<a[^>]+class="result__a"[^>]+href="[^"]*uddg=([^&"]+)[^"]*"[^>]*>'
-                r'(.*?)</a>',
-                re.IGNORECASE | re.DOTALL,
-            )
-            # Extract snippets from result__snippet anchors
-            snippet_re = re.compile(
-                r'<a[^>]+class="result__snippet"[^>]*>(.*?)</a>',
-                re.IGNORECASE | re.DOTALL,
-            )
-
-            title_matches = title_re.findall(html)
-            snippet_matches = [
-                re.sub(r"<[^>]+>", "", s).strip()
-                for s in snippet_re.findall(html)
-            ]
-
-            results: list[dict] = []
-            for i, (encoded_url, raw_title) in enumerate(title_matches):
-                if len(results) >= max_results:
-                    break
-                try:
-                    url = urllib.parse.unquote(encoded_url)
-                    if not url.startswith("http"):
-                        continue
-                    if _is_tooling_url(url):
-                        logger.debug("[discovery] DDG skip tooling domain: %s", url)
-                        continue
-                    title = re.sub(r"<[^>]+>", "", raw_title).strip()
-                    snippet = snippet_matches[i] if i < len(snippet_matches) else ""
-                    results.append({"url": url, "title": title, "snippet": snippet})
-                except Exception:
-                    pass
-
-            logger.info(
-                "[discovery] DuckDuckGo returned %d results for '%s': %s",
-                len(results), query, [r["url"] for r in results],
-            )
-            return results
-
-    except Exception as exc:
-        logger.warning("[discovery] DuckDuckGo search failed for '%s': %s", query, exc)
-        return []
-
-
-# ---------------------------------------------------------------------------
-# Claude Sonnet reasoning — picks the best URL from search results
+# Nova Web Grounding
 # ---------------------------------------------------------------------------
 
 class _DiscoveryResult(BaseModel):
     spec_url: str | None = Field(
         default=None,
-        description="Direct URL of the OpenAPI spec file, API index, or Swagger UI page.",
+        description="Direct URL of the OpenAPI spec file or API index root.",
     )
     title: str | None = Field(
         default=None,
@@ -291,115 +130,42 @@ class _DiscoveryResult(BaseModel):
     )
 
 
-_CLAUDE_PROMPT = """\
-You are helping find the OpenAPI/Swagger documentation URL for the '{query}' API.
+_DISCOVERY_PROMPT = """\
+Search the web for the OpenAPI/Swagger spec URL of the '{query}' API.
 
-Here are web search results:
-{results_json}
+Look for:
+1. Direct spec files: swagger.json, openapi.json, /v3/api-docs, /api-docs
+2. API index JSON (e.g. SWAPI: https://swapi.dev/api/ returns {{"people":"url",...}})
+3. Developer portal pages that link to the spec URL
 
-Analyze these results and identify the URL most likely to be:
-1. A direct OpenAPI spec file (swagger.json, openapi.json, /v3/api-docs, /api-docs)
-2. A Swagger UI or Redoc HTML documentation page (/swagger-ui.html, /ui/index.html, /docs)
-3. An API index endpoint that returns JSON with resource URLs
-
-Prefer:
-- Subdomains like docs., api., developer., swagger.
-- Paths containing api-docs, openapi, swagger, developer in the URL
-
-Avoid:
-- Marketing homepages (e.g. www.company.com with no API path)
-- Blog posts or tutorials about the API
-
-Return ONLY this JSON — no markdown, no explanation:
+Return ONLY this JSON object — no markdown, no explanation:
 {{"spec_url": "https://...", "title": "API Name", "candidate_host": null}}
 
 Rules:
-- spec_url: the best candidate URL found (null if nothing looks like API docs)
-- title: human-readable API name from the search results
-- candidate_host: scheme://host to probe with common spec paths when spec_url is null
-"""
-
-
-_CLAUDE_KNOWLEDGE_PROMPT = """\
-You are helping find the OpenAPI/Swagger documentation URL for the '{query}' API.
-Web search is unavailable. Use your training knowledge to answer.
-
-Return ONLY this JSON — no markdown, no explanation:
-{{"spec_url": "https://...", "title": "API Name", "candidate_host": "https://..."}}
-
-Rules:
-- spec_url: the most likely direct URL for the OpenAPI spec file or Swagger UI
+- spec_url: direct URL to the spec file or API index root (null if not found)
 - title: human-readable API name
-- candidate_host: scheme://host to probe with common spec paths (e.g. /swagger.json)
-- Return null for any field you are not confident about
+- candidate_host: base URL (scheme://host) to probe if spec_url is null
 """
 
 
-def _claude_knowledge_fallback_sync(query: str) -> _DiscoveryResult:
-    """
-    When web search is unavailable, ask Claude to recall the API docs URL
-    from its training knowledge.
-    """
+def _nova_grounding_sync(query: str) -> _DiscoveryResult:
+    """Call Nova Web Grounding synchronously (runs in thread pool)."""
     region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-    model_id = os.environ.get(
-        "DISCOVERY_MODEL_ID",
-        "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-    )
-    bedrock = boto3.client(
+    model_id = os.environ.get("INGESTION_AGENT_MODEL_ID", "us.amazon.nova-2-lite-v1:0")
+
+    client = boto3.client(
         "bedrock-runtime",
         region_name=region,
-        config=Config(read_timeout=30, connect_timeout=10),
+        config=Config(read_timeout=60, connect_timeout=10),
     )
-    prompt = _CLAUDE_KNOWLEDGE_PROMPT.format(query=query)
-    response = bedrock.converse(
+
+    response = client.converse(
         modelId=model_id,
-        messages=[{"role": "user", "content": [{"text": prompt}]}],
-    )
-    text_parts = [
-        c["text"]
-        for c in response.get("output", {}).get("message", {}).get("content", [])
-        if "text" in c
-    ]
-    raw_text = "\n".join(text_parts)
-    logger.info("[discovery] Claude knowledge fallback for '%s': %.400s", query, raw_text)
-    match = re.search(r'\{[^{}]*"spec_url"[^{}]*\}', raw_text, re.DOTALL)
-    if match:
-        result = _DiscoveryResult.model_validate(json.loads(match.group()))
-        logger.info(
-            "[discovery] Claude knowledge picked: spec_url=%s candidate=%s",
-            result.spec_url, result.candidate_host,
-        )
-        return result
-    return _DiscoveryResult()
-
-
-def _claude_pick_url_sync(query: str, results: list[dict]) -> _DiscoveryResult:
-    """
-    Use Claude Sonnet on Bedrock to reason about DuckDuckGo search results
-    and return the most likely OpenAPI spec or documentation URL.
-
-    Runs synchronously — call via asyncio.to_thread from async context.
-    """
-    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
-    model_id = os.environ.get(
-        "DISCOVERY_MODEL_ID",
-        "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-    )
-
-    bedrock = boto3.client(
-        "bedrock-runtime",
-        region_name=region,
-        config=Config(read_timeout=30, connect_timeout=10),
-    )
-
-    prompt = _CLAUDE_PROMPT.format(
-        query=query,
-        results_json=json.dumps(results, ensure_ascii=False, indent=2),
-    )
-
-    response = bedrock.converse(
-        modelId=model_id,
-        messages=[{"role": "user", "content": [{"text": prompt}]}],
+        messages=[{
+            "role": "user",
+            "content": [{"text": _DISCOVERY_PROMPT.format(query=query)}],
+        }],
+        toolConfig={"tools": [{"systemTool": {"name": "nova_grounding"}}]},
     )
 
     text_parts = [
@@ -408,18 +174,18 @@ def _claude_pick_url_sync(query: str, results: list[dict]) -> _DiscoveryResult:
         if "text" in c
     ]
     raw_text = "\n".join(text_parts)
-    logger.info("[discovery] Claude reasoning for '%s': %.400s", query, raw_text)
+    logger.info("[discovery] Nova Grounding raw for '%s': %.400s", query, raw_text)
 
     match = re.search(r'\{[^{}]*"spec_url"[^{}]*\}', raw_text, re.DOTALL)
     if match:
         result = _DiscoveryResult.model_validate(json.loads(match.group()))
         logger.info(
-            "[discovery] Claude picked: spec_url=%s candidate=%s",
+            "[discovery] Nova Grounding result: spec_url=%s candidate=%s",
             result.spec_url, result.candidate_host,
         )
         return result
 
-    logger.warning("[discovery] Claude returned no parseable JSON for '%s'", query)
+    logger.warning("[discovery] Nova Grounding returned no parseable JSON for '%s'", query)
     return _DiscoveryResult()
 
 
@@ -440,40 +206,23 @@ async def discover_openapi_url(query: str) -> dict | None:
     """
     Discover the OpenAPI/Swagger spec URL for a free-text *query*.
 
-    Uses DuckDuckGo (no API key) for web search and Claude Sonnet on Bedrock
-    to reason about which result is the real API documentation URL.
+    Uses Amazon Nova Web Grounding (nova_grounding system tool) to search
+    the web natively — no external API keys, no DuckDuckGo rate limits.
 
     Returns ``{"url": str, "title": str}`` on success, ``None`` otherwise.
     """
-    # Step 1: Search DuckDuckGo
-    results = await _duckduckgo_search(query)
-
-    # Step 2: Claude reasons about which URL is the spec/docs.
-    # When DDG is blocked (returns 202 / empty), fall back to Claude's
-    # training knowledge to suggest a candidate URL.
-    if results:
-        try:
-            discovery = await asyncio.to_thread(_claude_pick_url_sync, query, results)
-        except Exception as exc:
-            logger.error("[discovery] Claude reasoning failed for '%s': %s", query, exc)
-            discovery = _DiscoveryResult()
-    else:
-        logger.info(
-            "[discovery] No DDG results for '%s' — using Claude knowledge fallback",
-            query,
-        )
-        try:
-            discovery = await asyncio.to_thread(_claude_knowledge_fallback_sync, query)
-        except Exception as exc:
-            logger.error("[discovery] Claude knowledge fallback failed for '%s': %s", query, exc)
-            return None
+    try:
+        discovery = await asyncio.to_thread(_nova_grounding_sync, query)
+    except Exception as exc:
+        logger.error("[discovery] Nova Grounding failed for '%s': %s", query, exc)
+        return None
 
     async with httpx.AsyncClient(
         headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},
         follow_redirects=True,
     ) as client:
 
-        # Case A: Claude returned a specific spec/docs URL → verify it
+        # Case A: grounding returned a direct spec URL → verify it
         if discovery.spec_url:
             result = await _probe_url(client, discovery.spec_url)
             if result:
@@ -488,40 +237,18 @@ async def discover_openapi_url(query: str) -> dict | None:
                 for path in _SPEC_PATHS:
                     result = await _probe_url(client, host + path)
                     if result:
-                        logger.info(
-                            "[discovery] Found spec at %s (path probe on Claude pick)",
-                            result["url"],
-                        )
-                        return {
-                            "url": result["url"],
-                            "title": _extract_title(result["data"], query),
-                        }
+                        logger.info("[discovery] Found spec at %s (path probe)", result["url"])
+                        return {"url": result["url"], "title": _extract_title(result["data"], query)}
 
-        # Case B: Claude returned only a candidate host → probe common paths
+        # Case B: only a candidate host → probe common spec paths
         if discovery.candidate_host:
             host = discovery.candidate_host.rstrip("/")
             logger.info("[discovery] Probing candidate host: %s", host)
             for path in _SPEC_PATHS:
                 result = await _probe_url(client, host + path)
                 if result:
-                    return {
-                        "url": result["url"],
-                        "title": _extract_title(result["data"], query),
-                    }
-
-        # Case C: Claude found nothing useful → probe all DDG result URLs directly
-        logger.info(
-            "[discovery] Claude found no URL for '%s' — probing all DDG results",
-            query,
-        )
-        for ddg_result in results:
-            result = await _probe_url(client, ddg_result["url"])
-            if result:
-                title = _extract_title(result["data"], query) or ddg_result.get("title", query)
-                logger.info(
-                    "[discovery] Found spec at %s (DDG fallback)", result["url"]
-                )
-                return {"url": result["url"], "title": title}
+                    logger.info("[discovery] Found spec at %s", result["url"])
+                    return {"url": result["url"], "title": _extract_title(result["data"], query)}
 
     logger.info("[discovery] No spec found for query: %s", query)
     return None

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -199,9 +199,10 @@ async def _duckduckgo_search(query: str, max_results: int = 8) -> list[dict]:
     Uses the DuckDuckGo HTML endpoint — no API key needed.
     Result URLs are extracted from ``uddg=<encoded-url>`` href params.
     """
-    # Avoid "swagger" — it consistently pollutes results with SmartBear/Swagger.io
-    # which are API tooling sites, not the API we're looking for.
-    search_query = f"{query} REST API documentation openapi"
+    # "swagger" helps rank the actual Swagger UI page over the generic docs root
+    # (e.g. /ui/index.html vs just the domain). SmartBear/swagger.io are blocked
+    # by _TOOLING_DOMAINS so they won't pollute the results.
+    search_query = f"{query} REST API documentation openapi swagger"
     params = urllib.parse.urlencode({"q": search_query})
 
     try:

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -212,11 +212,17 @@ async def _duckduckgo_search(query: str, max_results: int = 8) -> list[dict]:
             timeout=15.0,
         ) as client:
             resp = await client.get(f"https://html.duckduckgo.com/html/?{params}")
-            if resp.status_code != 200:
+            if resp.status_code not in (200, 202):
                 logger.warning(
                     "[discovery] DuckDuckGo returned HTTP %s", resp.status_code
                 )
                 return []
+
+            if resp.status_code == 202:
+                logger.warning(
+                    "[discovery] DuckDuckGo returned HTTP 202 (bot-check) — "
+                    "attempting to parse body anyway"
+                )
 
             html = resp.text
 
@@ -314,6 +320,59 @@ Rules:
 """
 
 
+_CLAUDE_KNOWLEDGE_PROMPT = """\
+You are helping find the OpenAPI/Swagger documentation URL for the '{query}' API.
+Web search is unavailable. Use your training knowledge to answer.
+
+Return ONLY this JSON — no markdown, no explanation:
+{{"spec_url": "https://...", "title": "API Name", "candidate_host": "https://..."}}
+
+Rules:
+- spec_url: the most likely direct URL for the OpenAPI spec file or Swagger UI
+- title: human-readable API name
+- candidate_host: scheme://host to probe with common spec paths (e.g. /swagger.json)
+- Return null for any field you are not confident about
+"""
+
+
+def _claude_knowledge_fallback_sync(query: str) -> _DiscoveryResult:
+    """
+    When web search is unavailable, ask Claude to recall the API docs URL
+    from its training knowledge.
+    """
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    model_id = os.environ.get(
+        "DISCOVERY_MODEL_ID",
+        "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    )
+    bedrock = boto3.client(
+        "bedrock-runtime",
+        region_name=region,
+        config=Config(read_timeout=30, connect_timeout=10),
+    )
+    prompt = _CLAUDE_KNOWLEDGE_PROMPT.format(query=query)
+    response = bedrock.converse(
+        modelId=model_id,
+        messages=[{"role": "user", "content": [{"text": prompt}]}],
+    )
+    text_parts = [
+        c["text"]
+        for c in response.get("output", {}).get("message", {}).get("content", [])
+        if "text" in c
+    ]
+    raw_text = "\n".join(text_parts)
+    logger.info("[discovery] Claude knowledge fallback for '%s': %.400s", query, raw_text)
+    match = re.search(r'\{[^{}]*"spec_url"[^{}]*\}', raw_text, re.DOTALL)
+    if match:
+        result = _DiscoveryResult.model_validate(json.loads(match.group()))
+        logger.info(
+            "[discovery] Claude knowledge picked: spec_url=%s candidate=%s",
+            result.spec_url, result.candidate_host,
+        )
+        return result
+    return _DiscoveryResult()
+
+
 def _claude_pick_url_sync(query: str, results: list[dict]) -> _DiscoveryResult:
     """
     Use Claude Sonnet on Bedrock to reason about DuckDuckGo search results
@@ -389,17 +448,25 @@ async def discover_openapi_url(query: str) -> dict | None:
     # Step 1: Search DuckDuckGo
     results = await _duckduckgo_search(query)
 
-    if not results:
-        logger.info("[discovery] No DuckDuckGo results for '%s'", query)
-        return None
-
-    # Step 2: Claude reasons about which URL is the spec/docs
-    try:
-        discovery = await asyncio.to_thread(_claude_pick_url_sync, query, results)
-    except Exception as exc:
-        logger.error("[discovery] Claude reasoning failed for '%s': %s", query, exc)
-        # Fallback: treat all DDG results as candidates
-        discovery = _DiscoveryResult()
+    # Step 2: Claude reasons about which URL is the spec/docs.
+    # When DDG is blocked (returns 202 / empty), fall back to Claude's
+    # training knowledge to suggest a candidate URL.
+    if results:
+        try:
+            discovery = await asyncio.to_thread(_claude_pick_url_sync, query, results)
+        except Exception as exc:
+            logger.error("[discovery] Claude reasoning failed for '%s': %s", query, exc)
+            discovery = _DiscoveryResult()
+    else:
+        logger.info(
+            "[discovery] No DDG results for '%s' — using Claude knowledge fallback",
+            query,
+        )
+        try:
+            discovery = await asyncio.to_thread(_claude_knowledge_fallback_sync, query)
+        except Exception as exc:
+            logger.error("[discovery] Claude knowledge fallback failed for '%s': %s", query, exc)
+            return None
 
     async with httpx.AsyncClient(
         headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -1,9 +1,12 @@
-"""OpenAPI URL discovery via web search + LLM relevance filtering.
+"""OpenAPI URL discovery via web search + agentic browsing.
 
 Given a free-text API name (e.g. "Projuris", "Stripe"), this module:
 1. Searches DuckDuckGo for candidate URLs.
-2. Asks an LLM to identify which results are actually about the queried API.
-3. Probes only the LLM-selected candidates for a valid OpenAPI spec.
+2. Runs a Strands agent WITH a fetch_page tool so it can actively browse
+   candidate pages (docs portals, Swagger UIs, API indexes) to find the
+   actual OpenAPI spec URL — not just guess from snippets.
+3. Falls back to probing common spec paths on the selected host if the
+   agent cannot find the URL directly.
 """
 
 from __future__ import annotations
@@ -18,7 +21,7 @@ from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
-# Common OpenAPI spec paths to probe on a candidate host
+# Common OpenAPI spec paths to probe on a candidate host (fallback only)
 _SPEC_PATHS = [
     "/openapi.json",
     "/openapi.yaml",
@@ -43,7 +46,7 @@ _SPEC_PATHS = [
     "/api/v3/",
 ]
 
-_HTTP_TIMEOUT = 6.0  # seconds per probe
+_HTTP_TIMEOUT = 8.0  # seconds per probe
 
 
 def _is_openapi_spec(data: object) -> bool:
@@ -135,90 +138,184 @@ def _search_ddg(query: str) -> list[dict]:
     return all_results
 
 
-class _CandidateSelection(BaseModel):
-    """LLM output: ordered list of candidate URLs for the queried API."""
+def _fetch_page_content(url: str, max_chars: int = 4000) -> str:
+    """
+    Synchronous HTTP fetch that returns page content as plain text.
 
-    candidate_urls: list[str] = Field(
-        default_factory=list,
+    Used as a Strands @tool so the discovery agent can actively browse
+    candidate pages (docs portals, Swagger UIs, API root indexes) to find
+    the embedded OpenAPI spec URL rather than guessing from DDG snippets.
+
+    Returns a short, LLM-readable representation:
+    - JSON responses: raw JSON (truncated)
+    - HTML responses: extracted text with script/style tags stripped
+    - Other: first max_chars chars of body
+    """
+    import re as _re
+
+    try:
+        with httpx.Client(
+            follow_redirects=True,
+            timeout=_HTTP_TIMEOUT,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},
+        ) as client:
+            resp = client.get(url)
+
+        if resp.status_code != 200:
+            return f"HTTP {resp.status_code} for {url}"
+
+        content_type = resp.headers.get("content-type", "")
+        final_url = str(resp.url)
+        prefix = f"[fetched: {final_url}]\n"
+
+        if "json" in content_type or url.lower().endswith((".json", ".yaml", ".yml")):
+            return prefix + resp.text[:max_chars]
+
+        if "html" in content_type or resp.text.lstrip().startswith(("<!DOCTYPE", "<html")):
+            html = resp.text
+            # Strip <script> and <style> blocks — keep JS inline that configures Swagger
+            # but remove large library bundles. We keep short inline scripts.
+            html = _re.sub(r"<script\b[^>]*\bsrc\b[^>]*>.*?</script>", "", html,
+                           flags=_re.DOTALL | _re.IGNORECASE)
+            html = _re.sub(r"<style[^>]*>.*?</style>", "", html,
+                           flags=_re.DOTALL | _re.IGNORECASE)
+            # Keep inline <script> blocks (contain SwaggerUIBundle config)
+            # but strip all other HTML tags
+            text = _re.sub(r"<(?!script|/script)[^>]+>", " ", html)
+            text = _re.sub(r"\s+", " ", text).strip()
+            return prefix + text[:max_chars]
+
+        return prefix + resp.text[:max_chars]
+
+    except Exception as exc:
+        return f"Error fetching {url}: {exc}"
+
+
+class _DiscoveryResult(BaseModel):
+    """LLM output from the agentic discovery loop."""
+
+    spec_url: str | None = Field(
+        default=None,
         description=(
-            "Ordered list of URLs most likely to be the OpenAPI spec or official API "
-            "documentation for the queried API. Best candidate first. "
-            "Empty list if none of the results match the queried API."
+            "The direct URL of the OpenAPI/Swagger spec file or API index root. "
+            "Must be a URL that returns JSON or YAML when fetched directly. "
+            "Null if no spec could be found."
+        ),
+    )
+    title: str | None = Field(
+        default=None,
+        description="Human-readable name of the API, extracted from spec info.title or page title.",
+    )
+    candidate_host: str | None = Field(
+        default=None,
+        description=(
+            "If spec_url is null, the base host (scheme://host) of the most "
+            "likely API so the caller can probe common spec paths. "
+            "E.g. 'https://api.example.com'. Null if nothing was found."
         ),
     )
 
 
-def _llm_select_candidates_sync(query: str, results: list[dict]) -> list[str]:
+def _run_discovery_agent_sync(query: str, results: list[dict]) -> _DiscoveryResult:
     """
-    Strands agent that picks the most relevant URLs from DuckDuckGo search results.
+    Strands agent with a fetch_page tool that actively browses candidate pages
+    to discover the OpenAPI spec URL.
+
+    Unlike the old approach (LLM picks from snippets → code probes),
+    this agent can READ the actual page content:
+    - Swagger UI HTML → finds SwaggerUIBundle URL parameter
+    - API index JSON (SWAPI, Rick & Morty) → returns that URL directly
+    - Developer portal → navigates to the spec link
 
     Runs synchronously (called via asyncio.to_thread from async context).
-    Returns an ordered list of candidate URLs (best first), or an empty list
-    if the LLM finds no results genuinely related to the queried API.
     """
     import json
     import re
 
-    from strands import Agent
+    from strands import Agent, tool
     from strands.models import BedrockModel
 
     model_id = os.environ.get("INGESTION_AGENT_MODEL_ID", "us.amazon.nova-2-lite-v1:0")
 
+    @tool
+    def fetch_page(url: str) -> str:
+        """Fetch a URL and return its content as text. Use this to verify if
+        a page is an OpenAPI spec, API index, or Swagger UI that embeds a spec URL.
+
+        Args:
+            url: The URL to fetch (any HTTP/HTTPS URL).
+
+        Returns:
+            Page content as plain text (JSON kept as-is, HTML stripped of tags
+            but inline <script> blocks preserved to expose SwaggerUIBundle config).
+        """
+        logger.info("[discovery-agent] Fetching: %s", url)
+        return _fetch_page_content(url)
+
     agent = Agent(
         model=BedrockModel(model_id=model_id),
+        tools=[fetch_page],
         system_prompt=(
-            "You are an API documentation locator. Given a search query for a specific "
-            "API and a list of web search results, identify which URLs are most likely to be "
-            "the OpenAPI/Swagger spec file or official API documentation for that specific API.\n\n"
-            "Rules:\n"
-            "- Return the most likely candidate URLs or base domains even if you are not certain "
-            "a spec exists — the system will probe common paths (/openapi.json, /swagger.json, etc.) "
-            "automatically, so you don't need to confirm a spec is present.\n"
-            "- Prefer direct spec file URLs (.json, .yaml) over docs pages, but any domain that "
-            "plausibly hosts the API is a valid candidate.\n"
-            "- Return at most 3 candidates, ordered by confidence (best first).\n"
-            "- Only return an empty list if ALL results are clearly about a completely different "
-            "product or topic (e.g. query is 'Projuris' but results are all about 'Stripe').\n\n"
-            'Respond with ONLY a JSON object: {"candidate_urls": ["url1", "url2"]}'
+            "You are an OpenAPI spec locator. Your job is to find the actual "
+            "OpenAPI/Swagger spec URL for a given API.\n\n"
+            "You have a fetch_page tool — use it actively:\n"
+            "1. Scan search results for direct spec file URLs (.json/.yaml) or "
+            "developer portal / docs URLs.\n"
+            "2. For promising pages, call fetch_page(url) to read the content:\n"
+            "   - If it returns JSON with 'openapi'/'swagger'/'paths' keys → that IS the spec.\n"
+            "   - If it returns JSON where all values are URLs → that is an API index root "
+            "(treat it as the spec URL).\n"
+            "   - If it returns HTML containing 'SwaggerUIBundle' or 'spec-url' or 'Redoc' "
+            "→ look for the url: '...' parameter inside the script and fetch THAT URL.\n"
+            "3. Try at most 4 fetch_page calls to avoid timeouts.\n\n"
+            "When you find the spec URL, respond with ONLY this JSON (no markdown):\n"
+            '{"spec_url": "https://...", "title": "API Name", "candidate_host": null}\n\n'
+            "If you find a likely API host but not the exact spec URL:\n"
+            '{"spec_url": null, "title": null, "candidate_host": "https://api.example.com"}\n\n'
+            "If nothing is found:\n"
+            '{"spec_url": null, "title": null, "candidate_host": null}'
         ),
     )
 
     results_text = "\n".join(
         f"[{i + 1}] Title: {r.get('title', '')}\n"
         f"     URL: {r.get('href', '')}\n"
-        f"     Snippet: {r.get('body', '')[:300]}"
+        f"     Snippet: {r.get('body', '')[:200]}"
         for i, r in enumerate(results)
     )
 
     result = agent(
-        f"Query: '{query}'\n\n"
-        f"Search results:\n{results_text}\n\n"
-        f"Which URLs are the OpenAPI spec or official docs for '{query}'?"
+        f"Find the OpenAPI spec for: '{query}'\n\n"
+        f"Web search results:\n{results_text}\n\n"
+        f"Use fetch_page to verify and locate the spec. "
+        f"Return JSON with spec_url, title, and candidate_host."
     )
 
     try:
-        match = re.search(r'\{[^{}]*"candidate_urls"[^{}]*\}', str(result), re.DOTALL)
+        match = re.search(r'\{[^{}]*"spec_url"[^{}]*\}', str(result), re.DOTALL)
         if match:
             data = json.loads(match.group())
-            selection = _CandidateSelection.model_validate(data)
+            discovery = _DiscoveryResult.model_validate(data)
             logger.info(
-                "LLM selected %d candidate(s) for '%s': %s",
-                len(selection.candidate_urls), query, selection.candidate_urls,
+                "[discovery-agent] Result for '%s': spec_url=%s candidate_host=%s",
+                query, discovery.spec_url, discovery.candidate_host,
             )
-            return selection.candidate_urls
+            return discovery
     except Exception as exc:
-        logger.warning("Failed to parse LLM candidate selection: %s | raw: %.200s", exc, str(result))
+        logger.warning(
+            "Failed to parse discovery agent result: %s | raw: %.300s", exc, str(result)
+        )
 
-    return []
+    return _DiscoveryResult()
 
 
-async def _llm_select_candidates(query: str, results: list[dict]) -> list[str]:
+async def _run_discovery_agent(query: str, results: list[dict]) -> _DiscoveryResult:
     """Async wrapper — runs the synchronous Strands agent in a thread pool."""
     try:
-        return await asyncio.to_thread(_llm_select_candidates_sync, query, results)
+        return await asyncio.to_thread(_run_discovery_agent_sync, query, results)
     except Exception as exc:
-        logger.warning("LLM candidate selection failed: %s", exc)
-        return []
+        logger.warning("Discovery agent failed: %s", exc)
+        return _DiscoveryResult()
 
 
 def _extract_title(spec: dict, fallback: str) -> str:
@@ -236,8 +333,12 @@ async def discover_openapi_url(query: str) -> dict | None:
 
     Strategy:
     1. Search DuckDuckGo for candidates.
-    2. Ask an LLM to filter results to only those relevant to the queried API.
-    3. Probe LLM-selected URLs directly, then common spec paths on their hosts.
+    2. Run a Strands agent with a fetch_page tool — the agent actively browses
+       candidate pages (Swagger UI HTML, API index JSON, docs portals) to find
+       the spec URL instead of guessing from snippets.
+    3. If the agent found a spec_url directly → probe it to verify + extract title.
+    4. If the agent found only a candidate_host → probe common spec paths on it.
+    5. Keyword fallback if the agent found nothing.
 
     Returns ``{"url": str, "title": str}`` on success, ``None`` otherwise.
     """
@@ -253,40 +354,61 @@ async def discover_openapi_url(query: str) -> dict | None:
         [r.get("href", "") for r in all_results],
     )
 
-    # LLM filters search results to only relevant candidates
-    candidate_urls = await _llm_select_candidates(query, all_results)
-    if not candidate_urls:
-        # Fallback: keyword match on domain/title — the probe will verify if a spec exists
-        keyword = query.lower().split()[0]
-        candidate_urls = [
-            r["href"]
-            for r in all_results
-            if keyword in r.get("href", "").lower() or keyword in r.get("title", "").lower()
-            if r.get("href")
-        ][:3]
-        if candidate_urls:
-            logger.info(
-                "[discovery] LLM returned empty — keyword fallback found %d candidate(s): %s",
-                len(candidate_urls), candidate_urls,
-            )
-        else:
-            logger.info("[discovery] No candidates found for: %s", query)
-            return None
-
-    logger.info("[discovery] Probing %d candidate(s): %s", len(candidate_urls), candidate_urls)
+    # Agentic discovery: agent can browse pages to find the spec URL
+    discovery = await _run_discovery_agent(query, all_results)
 
     async with httpx.AsyncClient(
         headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},
         follow_redirects=True,
     ) as client:
-        for url in candidate_urls:
-            # Try the URL directly (may be a spec file or a Swagger UI page)
+
+        # Case 1: agent found a direct spec URL → verify it
+        if discovery.spec_url:
+            result = await _probe_url(client, discovery.spec_url)
+            if result:
+                logger.info("[discovery] Verified spec at %s (agent direct)", result["url"])
+                title = discovery.title or _extract_title(result["data"], query)
+                return {"url": result["url"], "title": title}
+            # Agent was confident but probe failed — try common paths on that host
+            logger.info(
+                "[discovery] Agent spec_url %s failed probe, trying host paths",
+                discovery.spec_url,
+            )
+            parsed = urlparse(discovery.spec_url)
+            host = f"{parsed.scheme}://{parsed.netloc}" if parsed.scheme and parsed.netloc else None
+            if host:
+                for path in _SPEC_PATHS:
+                    result = await _probe_url(client, host + path)
+                    if result:
+                        logger.info("[discovery] Found spec at %s (path probe)", result["url"])
+                        return {"url": result["url"], "title": _extract_title(result["data"], query)}
+
+        # Case 2: agent found a candidate host but not the spec URL → probe paths
+        if discovery.candidate_host:
+            host = discovery.candidate_host.rstrip("/")
+            logger.info("[discovery] Probing common paths on agent candidate: %s", host)
+            for path in _SPEC_PATHS:
+                result = await _probe_url(client, host + path)
+                if result:
+                    logger.info("[discovery] Found spec at %s (path probe on candidate)", result["url"])
+                    return {"url": result["url"], "title": _extract_title(result["data"], query)}
+
+        # Case 3: agent found nothing → keyword fallback from DDG results
+        logger.info("[discovery] Agent found nothing, trying keyword fallback")
+        keyword = query.lower().split()[0]
+        fallback_urls = [
+            r["href"]
+            for r in all_results
+            if keyword in r.get("href", "").lower() or keyword in r.get("title", "").lower()
+            if r.get("href")
+        ][:3]
+
+        for url in fallback_urls:
             result = await _probe_url(client, url)
             if result:
-                logger.info("Discovered spec at %s (direct probe)", result["url"])
+                logger.info("[discovery] Found spec at %s (keyword fallback)", result["url"])
                 return {"url": result["url"], "title": _extract_title(result["data"], query)}
 
-            # URL may be a docs/developer portal page — probe common spec paths on its host
             parsed = urlparse(url)
             if not (parsed.scheme and parsed.netloc):
                 continue
@@ -294,8 +416,8 @@ async def discover_openapi_url(query: str) -> dict | None:
             for path in _SPEC_PATHS:
                 result = await _probe_url(client, host + path)
                 if result:
-                    logger.info("Discovered spec at %s (path probe on %s)", result["url"], host)
+                    logger.info("[discovery] Found spec at %s (fallback path probe)", result["url"])
                     return {"url": result["url"], "title": _extract_title(result["data"], query)}
 
-    logger.info("No valid OpenAPI spec found for query: %s", query)
+    logger.info("[discovery] No valid OpenAPI spec found for query: %s", query)
     return None

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -1,27 +1,27 @@
-"""OpenAPI URL discovery via web search + agentic browsing.
+"""OpenAPI URL discovery via Amazon Nova Web Grounding.
 
-Given a free-text API name (e.g. "Projuris", "Stripe"), this module:
-1. Searches DuckDuckGo for candidate URLs.
-2. Runs a Strands agent WITH a fetch_page tool so it can actively browse
-   candidate pages (docs portals, Swagger UIs, API indexes) to find the
-   actual OpenAPI spec URL — not just guess from snippets.
-3. Falls back to probing common spec paths on the selected host if the
-   agent cannot find the URL directly.
+Given a free-text API name (e.g. "Projuris", "Star Wars"), this module:
+1. Asks Nova 2 Lite (with nova_grounding system tool) to find the spec URL.
+2. Probes the returned URL (or candidate host) to verify it's a real spec.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
+import re
 from urllib.parse import urlparse
 
+import boto3
 import httpx
+from botocore.config import Config
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
-# Common OpenAPI spec paths to probe on a candidate host (fallback only)
+# Common OpenAPI spec paths to probe on a candidate host
 _SPEC_PATHS = [
     "/openapi.json",
     "/openapi.yaml",
@@ -38,7 +38,7 @@ _SPEC_PATHS = [
     "/api/v3/openapi.json",
     "/swagger/v1/swagger.json",
     "/swagger/v2/swagger.json",
-    # API index roots (e.g. SWAPI, Rick & Morty) — no formal OpenAPI spec
+    # API index roots (e.g. SWAPI, Rick & Morty)
     "/api/",
     "/api",
     "/api/v1/",
@@ -46,7 +46,7 @@ _SPEC_PATHS = [
     "/api/v3/",
 ]
 
-_HTTP_TIMEOUT = 8.0  # seconds per probe
+_HTTP_TIMEOUT = 8.0
 
 
 def _is_openapi_spec(data: object) -> bool:
@@ -81,7 +81,6 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
         content_type = resp.headers.get("content-type", "")
         final_url = str(resp.url)
 
-        # JSON
         if "json" in content_type or url.lower().endswith((".json",)):
             try:
                 data = resp.json()
@@ -90,18 +89,15 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
             except Exception:
                 pass
 
-        # YAML
         if "yaml" in content_type or url.lower().endswith((".yaml", ".yml")):
             try:
                 import yaml
-
                 data = yaml.safe_load(resp.text)
                 if _is_openapi_spec(data) or _is_api_index(data):
                     return {"url": final_url, "data": data}
             except Exception:
                 pass
 
-        # HTML — look for embedded Swagger UI / Redoc spec URL (one level deep)
         if "html" in content_type:
             spec_url = extract_swagger_spec_url(resp.text, url)
             if spec_url:
@@ -115,208 +111,87 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
     return None
 
 
-def _search_ddg(query: str) -> list[dict]:
-    """Synchronous DuckDuckGo search — runs in a thread executor."""
-    from ddgs import DDGS
-
-    # Append "API" if the user didn't mention it, so generic terms like
-    # "starwars" or "weather" target API docs instead of unrelated content.
-    q = query if any(w in query.lower() for w in ("api", "swagger", "openapi")) else f"{query} API"
-
-    all_results: list[dict] = []
-    ddgs = DDGS()
-    search_queries = [
-        f"{q} openapi swagger json spec",
-        f"{q} swagger.json OR openapi.json",
-    ]
-    for sq in search_queries:
-        try:
-            results = ddgs.text(sq, max_results=8)
-            all_results.extend(results or [])
-        except Exception as exc:
-            logger.warning("DDG search failed for '%s': %s", sq, exc)
-    return all_results
-
-
-def _fetch_page_content(url: str, max_chars: int = 4000) -> str:
-    """
-    Synchronous HTTP fetch that returns page content as plain text.
-
-    Used as a Strands @tool so the discovery agent can actively browse
-    candidate pages (docs portals, Swagger UIs, API root indexes) to find
-    the embedded OpenAPI spec URL rather than guessing from DDG snippets.
-
-    Returns a short, LLM-readable representation:
-    - JSON responses: raw JSON (truncated)
-    - HTML responses: extracted text with script/style tags stripped
-    - Other: first max_chars chars of body
-    """
-    import re as _re
-
-    try:
-        with httpx.Client(
-            follow_redirects=True,
-            timeout=_HTTP_TIMEOUT,
-            headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},
-        ) as client:
-            resp = client.get(url)
-
-        if resp.status_code != 200:
-            return f"HTTP {resp.status_code} for {url}"
-
-        content_type = resp.headers.get("content-type", "")
-        final_url = str(resp.url)
-        prefix = f"[fetched: {final_url}]\n"
-
-        if "json" in content_type or url.lower().endswith((".json", ".yaml", ".yml")):
-            return prefix + resp.text[:max_chars]
-
-        if "html" in content_type or resp.text.lstrip().startswith(("<!DOCTYPE", "<html")):
-            html = resp.text
-            # Strip <script> and <style> blocks — keep JS inline that configures Swagger
-            # but remove large library bundles. We keep short inline scripts.
-            html = _re.sub(r"<script\b[^>]*\bsrc\b[^>]*>.*?</script>", "", html,
-                           flags=_re.DOTALL | _re.IGNORECASE)
-            html = _re.sub(r"<style[^>]*>.*?</style>", "", html,
-                           flags=_re.DOTALL | _re.IGNORECASE)
-            # Keep inline <script> blocks (contain SwaggerUIBundle config)
-            # but strip all other HTML tags
-            text = _re.sub(r"<(?!script|/script)[^>]+>", " ", html)
-            text = _re.sub(r"\s+", " ", text).strip()
-            return prefix + text[:max_chars]
-
-        return prefix + resp.text[:max_chars]
-
-    except Exception as exc:
-        return f"Error fetching {url}: {exc}"
-
+# ---------------------------------------------------------------------------
+# Nova Web Grounding
+# ---------------------------------------------------------------------------
 
 class _DiscoveryResult(BaseModel):
-    """LLM output from the agentic discovery loop."""
-
     spec_url: str | None = Field(
         default=None,
-        description=(
-            "The direct URL of the OpenAPI/Swagger spec file or API index root. "
-            "Must be a URL that returns JSON or YAML when fetched directly. "
-            "Null if no spec could be found."
-        ),
+        description="Direct URL of the OpenAPI spec file or API index root.",
     )
     title: str | None = Field(
         default=None,
-        description="Human-readable name of the API, extracted from spec info.title or page title.",
+        description="Human-readable API name.",
     )
     candidate_host: str | None = Field(
         default=None,
-        description=(
-            "If spec_url is null, the base host (scheme://host) of the most "
-            "likely API so the caller can probe common spec paths. "
-            "E.g. 'https://api.example.com'. Null if nothing was found."
-        ),
+        description="Base host to probe with common spec paths when spec_url is null.",
     )
 
 
-def _run_discovery_agent_sync(query: str, results: list[dict]) -> _DiscoveryResult:
-    """
-    Strands agent with a fetch_page tool that actively browses candidate pages
-    to discover the OpenAPI spec URL.
+_DISCOVERY_PROMPT = """\
+Search the web for the OpenAPI/Swagger spec URL of the '{query}' API.
 
-    Unlike the old approach (LLM picks from snippets → code probes),
-    this agent can READ the actual page content:
-    - Swagger UI HTML → finds SwaggerUIBundle URL parameter
-    - API index JSON (SWAPI, Rick & Morty) → returns that URL directly
-    - Developer portal → navigates to the spec link
+Look for:
+1. Direct spec files: swagger.json, openapi.json, /v3/api-docs, /api-docs
+2. API index JSON (e.g. SWAPI: https://swapi.dev/api/ returns {{"people":"url",...}})
+3. Developer portal pages that link to the spec URL
 
-    Runs synchronously (called via asyncio.to_thread from async context).
-    """
-    import json
-    import re
+Return ONLY this JSON object — no markdown, no explanation:
+{{"spec_url": "https://...", "title": "API Name", "candidate_host": null}}
 
-    from strands import Agent, tool
-    from strands.models import BedrockModel
+Rules:
+- spec_url: direct URL to the spec file or API index root (null if not found)
+- title: human-readable API name
+- candidate_host: base URL (scheme://host) to probe if spec_url is null
+"""
 
+
+def _nova_grounding_sync(query: str) -> _DiscoveryResult:
+    """Call Nova Web Grounding synchronously (runs in thread pool)."""
+    region = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
     model_id = os.environ.get("INGESTION_AGENT_MODEL_ID", "us.amazon.nova-2-lite-v1:0")
 
-    @tool
-    def fetch_page(url: str) -> str:
-        """Fetch a URL and return its content as text. Use this to verify if
-        a page is an OpenAPI spec, API index, or Swagger UI that embeds a spec URL.
-
-        Args:
-            url: The URL to fetch (any HTTP/HTTPS URL).
-
-        Returns:
-            Page content as plain text (JSON kept as-is, HTML stripped of tags
-            but inline <script> blocks preserved to expose SwaggerUIBundle config).
-        """
-        logger.info("[discovery-agent] Fetching: %s", url)
-        return _fetch_page_content(url)
-
-    agent = Agent(
-        model=BedrockModel(model_id=model_id),
-        tools=[fetch_page],
-        system_prompt=(
-            "You are an OpenAPI spec locator. Your job is to find the actual "
-            "OpenAPI/Swagger spec URL for a given API.\n\n"
-            "You have a fetch_page tool — use it actively:\n"
-            "1. Scan search results for direct spec file URLs (.json/.yaml) or "
-            "developer portal / docs URLs.\n"
-            "2. For promising pages, call fetch_page(url) to read the content:\n"
-            "   - If it returns JSON with 'openapi'/'swagger'/'paths' keys → that IS the spec.\n"
-            "   - If it returns JSON where all values are URLs → that is an API index root "
-            "(treat it as the spec URL).\n"
-            "   - If it returns HTML containing 'SwaggerUIBundle' or 'spec-url' or 'Redoc' "
-            "→ look for the url: '...' parameter inside the script and fetch THAT URL.\n"
-            "3. Try at most 4 fetch_page calls to avoid timeouts.\n\n"
-            "When you find the spec URL, respond with ONLY this JSON (no markdown):\n"
-            '{"spec_url": "https://...", "title": "API Name", "candidate_host": null}\n\n'
-            "If you find a likely API host but not the exact spec URL:\n"
-            '{"spec_url": null, "title": null, "candidate_host": "https://api.example.com"}\n\n'
-            "If nothing is found:\n"
-            '{"spec_url": null, "title": null, "candidate_host": null}'
-        ),
+    client = boto3.client(
+        "bedrock-runtime",
+        region_name=region,
+        config=Config(read_timeout=60, connect_timeout=10),
     )
 
-    results_text = "\n".join(
-        f"[{i + 1}] Title: {r.get('title', '')}\n"
-        f"     URL: {r.get('href', '')}\n"
-        f"     Snippet: {r.get('body', '')[:200]}"
-        for i, r in enumerate(results)
+    response = client.converse(
+        modelId=model_id,
+        messages=[{
+            "role": "user",
+            "content": [{"text": _DISCOVERY_PROMPT.format(query=query)}],
+        }],
+        toolConfig={"tools": [{"systemTool": {"name": "nova_grounding"}}]},
     )
 
-    result = agent(
-        f"Find the OpenAPI spec for: '{query}'\n\n"
-        f"Web search results:\n{results_text}\n\n"
-        f"Use fetch_page to verify and locate the spec. "
-        f"Return JSON with spec_url, title, and candidate_host."
-    )
+    text_parts = [
+        c["text"]
+        for c in response.get("output", {}).get("message", {}).get("content", [])
+        if "text" in c
+    ]
+    raw_text = "\n".join(text_parts)
+    logger.info("[discovery] Nova Grounding raw for '%s': %.400s", query, raw_text)
 
-    try:
-        match = re.search(r'\{[^{}]*"spec_url"[^{}]*\}', str(result), re.DOTALL)
-        if match:
-            data = json.loads(match.group())
-            discovery = _DiscoveryResult.model_validate(data)
-            logger.info(
-                "[discovery-agent] Result for '%s': spec_url=%s candidate_host=%s",
-                query, discovery.spec_url, discovery.candidate_host,
-            )
-            return discovery
-    except Exception as exc:
-        logger.warning(
-            "Failed to parse discovery agent result: %s | raw: %.300s", exc, str(result)
+    match = re.search(r'\{[^{}]*"spec_url"[^{}]*\}', raw_text, re.DOTALL)
+    if match:
+        result = _DiscoveryResult.model_validate(json.loads(match.group()))
+        logger.info(
+            "[discovery] Nova Grounding result: spec_url=%s candidate=%s",
+            result.spec_url, result.candidate_host,
         )
+        return result
 
+    logger.warning("[discovery] Nova Grounding returned no parseable JSON for '%s'", query)
     return _DiscoveryResult()
 
 
-async def _run_discovery_agent(query: str, results: list[dict]) -> _DiscoveryResult:
-    """Async wrapper — runs the synchronous Strands agent in a thread pool."""
-    try:
-        return await asyncio.to_thread(_run_discovery_agent_sync, query, results)
-    except Exception as exc:
-        logger.warning("Discovery agent failed: %s", exc)
-        return _DiscoveryResult()
-
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
 
 def _extract_title(spec: dict, fallback: str) -> str:
     info = spec.get("info", {})
@@ -331,93 +206,49 @@ async def discover_openapi_url(query: str) -> dict | None:
     """
     Discover the OpenAPI/Swagger spec URL for a free-text *query*.
 
-    Strategy:
-    1. Search DuckDuckGo for candidates.
-    2. Run a Strands agent with a fetch_page tool — the agent actively browses
-       candidate pages (Swagger UI HTML, API index JSON, docs portals) to find
-       the spec URL instead of guessing from snippets.
-    3. If the agent found a spec_url directly → probe it to verify + extract title.
-    4. If the agent found only a candidate_host → probe common spec paths on it.
-    5. Keyword fallback if the agent found nothing.
+    Uses Amazon Nova Web Grounding (nova_grounding system tool) to search
+    the web natively — no external API keys, no DuckDuckGo rate limits.
 
     Returns ``{"url": str, "title": str}`` on success, ``None`` otherwise.
     """
-    all_results = await asyncio.to_thread(_search_ddg, query)
-    if not all_results:
-        logger.info("[discovery] No DDG results for query: %s", query)
+    try:
+        discovery = await asyncio.to_thread(_nova_grounding_sync, query)
+    except Exception as exc:
+        logger.error("[discovery] Nova Grounding failed for '%s': %s", query, exc)
         return None
-
-    logger.info(
-        "[discovery] DDG returned %d results for '%s': %s",
-        len(all_results),
-        query,
-        [r.get("href", "") for r in all_results],
-    )
-
-    # Agentic discovery: agent can browse pages to find the spec URL
-    discovery = await _run_discovery_agent(query, all_results)
 
     async with httpx.AsyncClient(
         headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},
         follow_redirects=True,
     ) as client:
 
-        # Case 1: agent found a direct spec URL → verify it
+        # Case A: grounding returned a direct spec URL → verify it
         if discovery.spec_url:
             result = await _probe_url(client, discovery.spec_url)
             if result:
-                logger.info("[discovery] Verified spec at %s (agent direct)", result["url"])
                 title = discovery.title or _extract_title(result["data"], query)
+                logger.info("[discovery] Verified spec at %s", result["url"])
                 return {"url": result["url"], "title": title}
-            # Agent was confident but probe failed — try common paths on that host
-            logger.info(
-                "[discovery] Agent spec_url %s failed probe, trying host paths",
-                discovery.spec_url,
-            )
+
+            # URL suggested but probe failed → try common paths on that host
             parsed = urlparse(discovery.spec_url)
-            host = f"{parsed.scheme}://{parsed.netloc}" if parsed.scheme and parsed.netloc else None
-            if host:
+            if parsed.scheme and parsed.netloc:
+                host = f"{parsed.scheme}://{parsed.netloc}"
                 for path in _SPEC_PATHS:
                     result = await _probe_url(client, host + path)
                     if result:
                         logger.info("[discovery] Found spec at %s (path probe)", result["url"])
                         return {"url": result["url"], "title": _extract_title(result["data"], query)}
 
-        # Case 2: agent found a candidate host but not the spec URL → probe paths
+        # Case B: only a candidate host → probe common spec paths
         if discovery.candidate_host:
             host = discovery.candidate_host.rstrip("/")
-            logger.info("[discovery] Probing common paths on agent candidate: %s", host)
+            logger.info("[discovery] Probing candidate host: %s", host)
             for path in _SPEC_PATHS:
                 result = await _probe_url(client, host + path)
                 if result:
-                    logger.info("[discovery] Found spec at %s (path probe on candidate)", result["url"])
+                    logger.info("[discovery] Found spec at %s", result["url"])
                     return {"url": result["url"], "title": _extract_title(result["data"], query)}
 
-        # Case 3: agent found nothing → keyword fallback from DDG results
-        logger.info("[discovery] Agent found nothing, trying keyword fallback")
-        keyword = query.lower().split()[0]
-        fallback_urls = [
-            r["href"]
-            for r in all_results
-            if keyword in r.get("href", "").lower() or keyword in r.get("title", "").lower()
-            if r.get("href")
-        ][:3]
-
-        for url in fallback_urls:
-            result = await _probe_url(client, url)
-            if result:
-                logger.info("[discovery] Found spec at %s (keyword fallback)", result["url"])
-                return {"url": result["url"], "title": _extract_title(result["data"], query)}
-
-            parsed = urlparse(url)
-            if not (parsed.scheme and parsed.netloc):
-                continue
-            host = f"{parsed.scheme}://{parsed.netloc}"
-            for path in _SPEC_PATHS:
-                result = await _probe_url(client, host + path)
-                if result:
-                    logger.info("[discovery] Found spec at %s (fallback path probe)", result["url"])
-                    return {"url": result["url"], "title": _extract_title(result["data"], query)}
-
-    logger.info("[discovery] No valid OpenAPI spec found for query: %s", query)
+    logger.info("[discovery] No spec found for query: %s", query)
     return None

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -107,7 +107,7 @@ async def _probe_url(client: httpx.AsyncClient, url: str) -> dict | None:
                     return inner
 
     except Exception as exc:
-        logger.debug("Probe failed for %s: %s", url, exc)
+        logger.warning("[discovery] Probe failed for %s: %s", url, exc)
 
     return None
 
@@ -241,14 +241,23 @@ async def discover_openapi_url(query: str) -> dict | None:
     """
     all_results = await asyncio.to_thread(_search_ddg, query)
     if not all_results:
-        logger.info("No DDG results for query: %s", query)
+        logger.info("[discovery] No DDG results for query: %s", query)
         return None
+
+    logger.info(
+        "[discovery] DDG returned %d results for '%s': %s",
+        len(all_results),
+        query,
+        [r.get("href", "") for r in all_results],
+    )
 
     # LLM filters search results to only relevant candidates
     candidate_urls = await _llm_select_candidates(query, all_results)
     if not candidate_urls:
-        logger.info("No relevant candidates found for: %s", query)
+        logger.info("[discovery] LLM found no relevant candidates for: %s", query)
         return None
+
+    logger.info("[discovery] Probing %d candidate(s): %s", len(candidate_urls), candidate_urls)
 
     async with httpx.AsyncClient(
         headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -148,32 +148,36 @@ class _CandidateSelection(BaseModel):
     )
 
 
-async def _llm_select_candidates(query: str, results: list[dict]) -> list[str]:
+def _llm_select_candidates_sync(query: str, results: list[dict]) -> list[str]:
     """
-    Ask an LLM to pick the most relevant URLs from DuckDuckGo search results.
+    Strands agent that picks the most relevant URLs from DuckDuckGo search results.
 
+    Runs synchronously (called via asyncio.to_thread from async context).
     Returns an ordered list of candidate URLs (best first), or an empty list
     if the LLM finds no results genuinely related to the queried API.
     """
-    from pydantic_ai import Agent
+    import json
+    import re
 
-    model = os.environ.get("INGESTION_AGENT_MODEL", "bedrock:us.amazon.nova-2-lite-v1:0")
+    from strands import Agent
+    from strands.models import BedrockModel
+
+    model_id = os.environ.get("INGESTION_AGENT_MODEL_ID", "us.amazon.nova-2-lite-v1:0")
 
     agent = Agent(
-        model,
-        output_type=_CandidateSelection,
+        model=BedrockModel(model_id=model_id),
         system_prompt=(
             "You are an API documentation locator. Given a search query for a specific "
-            "API and a list of web search results, identify which URLs are most likely to be:\n"
-            "  1. The OpenAPI/Swagger spec file for that specific API\n"
-            "  2. The official API documentation or developer portal for that specific API\n\n"
+            "API and a list of web search results, identify which URLs are most likely to be "
+            "the OpenAPI/Swagger spec file or official API documentation for that specific API.\n\n"
             "Rules:\n"
-            "- ONLY return URLs genuinely related to the queried API — not to generic tools, "
-            "tutorials, or completely unrelated APIs that happened to appear in search results.\n"
+            "- ONLY return URLs genuinely related to the queried API — not generic tools, "
+            "tutorials, or unrelated APIs that happened to appear in results.\n"
             "- If none of the results are about the queried API, return an empty list.\n"
             "- Prefer direct spec file URLs (.json, .yaml) over docs pages.\n"
             "- Return at most 3 candidates, ordered by confidence (best first).\n"
-            "- Be conservative: a wrong API is worse than returning nothing."
+            "- Be conservative: a wrong API is worse than returning nothing.\n\n"
+            'Respond with ONLY a JSON object: {"candidate_urls": ["url1", "url2"]}'
         ),
     )
 
@@ -184,15 +188,32 @@ async def _llm_select_candidates(query: str, results: list[dict]) -> list[str]:
         for i, r in enumerate(results)
     )
 
+    result = agent(
+        f"Query: '{query}'\n\n"
+        f"Search results:\n{results_text}\n\n"
+        f"Which URLs are the OpenAPI spec or official docs for '{query}'?"
+    )
+
     try:
-        result = await agent.run(
-            f"Query: '{query}'\n\n"
-            f"Search results:\n{results_text}\n\n"
-            f"Which URLs are the OpenAPI spec or official docs for '{query}'?"
-        )
-        urls = result.output.candidate_urls
-        logger.info("LLM selected %d candidate(s) for '%s': %s", len(urls), query, urls)
-        return urls
+        match = re.search(r'\{[^{}]*"candidate_urls"[^{}]*\}', str(result), re.DOTALL)
+        if match:
+            data = json.loads(match.group())
+            selection = _CandidateSelection.model_validate(data)
+            logger.info(
+                "LLM selected %d candidate(s) for '%s': %s",
+                len(selection.candidate_urls), query, selection.candidate_urls,
+            )
+            return selection.candidate_urls
+    except Exception as exc:
+        logger.warning("Failed to parse LLM candidate selection: %s | raw: %.200s", exc, str(result))
+
+    return []
+
+
+async def _llm_select_candidates(query: str, results: list[dict]) -> list[str]:
+    """Async wrapper — runs the synchronous Strands agent in a thread pool."""
+    try:
+        return await asyncio.to_thread(_llm_select_candidates_sync, query, results)
     except Exception as exc:
         logger.warning("LLM candidate selection failed: %s", exc)
         return []

--- a/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/discovery.py
@@ -1,22 +1,24 @@
-"""OpenAPI URL discovery via web search.
+"""OpenAPI URL discovery via web search + LLM relevance filtering.
 
-Given a free-text API name (e.g. "Stripe", "PokeAPI"), this module searches
-DuckDuckGo for candidate OpenAPI/Swagger specs, probes common URL patterns on
-each host, validates each candidate, and returns the single best result — or
-None if no valid spec is found.
+Given a free-text API name (e.g. "Projuris", "Stripe"), this module:
+1. Searches DuckDuckGo for candidate URLs.
+2. Asks an LLM to identify which results are actually about the queried API.
+3. Probes only the LLM-selected candidates for a valid OpenAPI spec.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from urllib.parse import urlparse
 
 import httpx
+from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
 
-# Common OpenAPI spec paths to probe on each candidate host
+# Common OpenAPI spec paths to probe on a candidate host
 _SPEC_PATHS = [
     "/openapi.json",
     "/openapi.yaml",
@@ -40,9 +42,6 @@ _SPEC_PATHS = [
     "/api/v2/",
     "/api/v3/",
 ]
-
-# URL fragments that strongly suggest an OpenAPI spec path
-_SPEC_FRAGMENTS = ("/openapi", "/swagger", "/api-docs")
 
 _HTTP_TIMEOUT = 6.0  # seconds per probe
 
@@ -136,23 +135,67 @@ def _search_ddg(query: str) -> list[dict]:
     return all_results
 
 
-def _candidate_hosts(results: list[dict]) -> list[str]:
-    """Extract unique base hosts from search results, preserving order."""
-    seen: set[str] = set()
-    hosts: list[str] = []
-    for r in results:
-        href = r.get("href", "")
-        if not href:
-            continue
-        try:
-            parsed = urlparse(href)
-            host = f"{parsed.scheme}://{parsed.netloc}"
-            if host not in seen:
-                seen.add(host)
-                hosts.append(host)
-        except Exception:
-            continue
-    return hosts
+class _CandidateSelection(BaseModel):
+    """LLM output: ordered list of candidate URLs for the queried API."""
+
+    candidate_urls: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Ordered list of URLs most likely to be the OpenAPI spec or official API "
+            "documentation for the queried API. Best candidate first. "
+            "Empty list if none of the results match the queried API."
+        ),
+    )
+
+
+async def _llm_select_candidates(query: str, results: list[dict]) -> list[str]:
+    """
+    Ask an LLM to pick the most relevant URLs from DuckDuckGo search results.
+
+    Returns an ordered list of candidate URLs (best first), or an empty list
+    if the LLM finds no results genuinely related to the queried API.
+    """
+    from pydantic_ai import Agent
+
+    model = os.environ.get("INGESTION_AGENT_MODEL", "bedrock:us.amazon.nova-2-lite-v1:0")
+
+    agent = Agent(
+        model,
+        output_type=_CandidateSelection,
+        system_prompt=(
+            "You are an API documentation locator. Given a search query for a specific "
+            "API and a list of web search results, identify which URLs are most likely to be:\n"
+            "  1. The OpenAPI/Swagger spec file for that specific API\n"
+            "  2. The official API documentation or developer portal for that specific API\n\n"
+            "Rules:\n"
+            "- ONLY return URLs genuinely related to the queried API — not to generic tools, "
+            "tutorials, or completely unrelated APIs that happened to appear in search results.\n"
+            "- If none of the results are about the queried API, return an empty list.\n"
+            "- Prefer direct spec file URLs (.json, .yaml) over docs pages.\n"
+            "- Return at most 3 candidates, ordered by confidence (best first).\n"
+            "- Be conservative: a wrong API is worse than returning nothing."
+        ),
+    )
+
+    results_text = "\n".join(
+        f"[{i + 1}] Title: {r.get('title', '')}\n"
+        f"     URL: {r.get('href', '')}\n"
+        f"     Snippet: {r.get('body', '')[:300]}"
+        for i, r in enumerate(results)
+    )
+
+    try:
+        result = await agent.run(
+            f"Query: '{query}'\n\n"
+            f"Search results:\n{results_text}\n\n"
+            f"Which URLs are the OpenAPI spec or official docs for '{query}'?"
+        )
+        urls = result.output.candidate_urls
+        logger.info("LLM selected %d candidate(s) for '%s': %s", len(urls), query, urls)
+        return urls
+    except Exception as exc:
+        logger.warning("LLM candidate selection failed: %s", exc)
+        return []
 
 
 def _extract_title(spec: dict, fallback: str) -> str:
@@ -169,9 +212,9 @@ async def discover_openapi_url(query: str) -> dict | None:
     Discover the OpenAPI/Swagger spec URL for a free-text *query*.
 
     Strategy:
-    1. Search DuckDuckGo for ``"{query} openapi swagger json spec"``.
-    2. Probe direct URLs from results that look like spec files.
-    3. Probe common spec paths on the top candidate hosts.
+    1. Search DuckDuckGo for candidates.
+    2. Ask an LLM to filter results to only those relevant to the queried API.
+    3. Probe LLM-selected URLs directly, then common spec paths on their hosts.
 
     Returns ``{"url": str, "title": str}`` on success, ``None`` otherwise.
     """
@@ -180,32 +223,32 @@ async def discover_openapi_url(query: str) -> dict | None:
         logger.info("No DDG results for query: %s", query)
         return None
 
+    # LLM filters search results to only relevant candidates
+    candidate_urls = await _llm_select_candidates(query, all_results)
+    if not candidate_urls:
+        logger.info("No relevant candidates found for: %s", query)
+        return None
+
     async with httpx.AsyncClient(
         headers={"User-Agent": "Mozilla/5.0 (compatible; DataLakeDiscoveryBot/1.0)"},
         follow_redirects=True,
     ) as client:
-        # --- Pass 1: probe direct URLs from search results that look like specs ---
-        for r in all_results:
-            href = r.get("href", "")
-            if not href:
-                continue
-            looks_like_spec = href.lower().endswith(
-                (".json", ".yaml", ".yml")
-            ) or any(frag in href for frag in _SPEC_FRAGMENTS)
-            if not looks_like_spec:
-                continue
-            result = await _probe_url(client, href)
+        for url in candidate_urls:
+            # Try the URL directly (may be a spec file or a Swagger UI page)
+            result = await _probe_url(client, url)
             if result:
-                logger.info("Discovered spec at %s (direct URL)", result["url"])
+                logger.info("Discovered spec at %s (direct probe)", result["url"])
                 return {"url": result["url"], "title": _extract_title(result["data"], query)}
 
-        # --- Pass 2: probe common spec paths on top candidate hosts ---
-        hosts = _candidate_hosts(all_results)
-        for host in hosts[:5]:
+            # URL may be a docs/developer portal page — probe common spec paths on its host
+            parsed = urlparse(url)
+            if not (parsed.scheme and parsed.netloc):
+                continue
+            host = f"{parsed.scheme}://{parsed.netloc}"
             for path in _SPEC_PATHS:
                 result = await _probe_url(client, host + path)
                 if result:
-                    logger.info("Discovered spec at %s (path probe)", result["url"])
+                    logger.info("Discovered spec at %s (path probe on %s)", result["url"], host)
                     return {"url": result["url"], "title": _extract_title(result["data"], query)}
 
     logger.info("No valid OpenAPI spec found for query: %s", query)

--- a/lambdas/ingestion_agent/agents/ingestion_agent/openapi_analyzer.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/openapi_analyzer.py
@@ -125,7 +125,16 @@ Rules:
        /query, /filter, /list, /find, /pesquisa) AND there is no GET endpoint \
        for the same resource that already covers the same data. \
     d) ALWAYS prefer GET over POST. If GET and POST both exist for the same path \
-       or same logical resource, include ONLY the GET and drop the POST entirely.
+       or same logical resource, include ONLY the GET and drop the POST entirely. \
+    e) UTILITY/PROCESSING ENDPOINTS — Endpoints that transform, convert, format, \
+       validate, minify, prettify, parse, or otherwise process a single input value \
+       are NOT data sources. They return a processed version of the caller's input, \
+       not a collection of stored records. NEVER include these in an ingestion plan. \
+       Recognition signals: POST method + single-object response (not an array) + \
+       path/summary focused on processing/transforming/validating an input \
+       (e.g., /format, /validate, /convert, /parse, /minify, /transform, /render). \
+       If ALL endpoints in the spec are utility/processing endpoints, return an \
+       IngestionPlan with an empty endpoints list.
 14. PARENT-PREFIX PATHS — If a parameterless path is also a common prefix of \
     other paths in the spec (i.e., other paths start with it), the parent path \
     is likely a namespace or router, NOT a real collection endpoint. \

--- a/lambdas/ingestion_agent/agents/ingestion_agent/runner.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/runner.py
@@ -56,9 +56,7 @@ def _safe_distributions(**kwargs):  # type: ignore[no-untyped-def]
 _meta.distributions = _safe_distributions  # type: ignore[assignment]
 # ---------------------------------------------------------------------------
 
-import dlt
 import httpx
-from dlt.sources.rest_api import rest_api_source
 
 from agents.ingestion_agent.models import EndpointSpec, IngestionPlan, OAuth2Config
 
@@ -835,6 +833,7 @@ def make_destination(api_url: str, domain: str, batch_size: int = 25, api_key: s
         {table_name: total_records_sent}.  dlt's own LoadInfo.rows_count is
         unreliable for custom destinations, so we track it ourselves.
     """
+    import dlt  # lazy — only needed in ECS, not in the Lambda
     base = api_url.rstrip("/")
     internal_headers = {"x-api-key": api_key} if api_key else {}
 
@@ -915,6 +914,9 @@ def run_pipeline(
 
     Returns a dict of {resource_name: records_loaded}.
     """
+    import dlt  # lazy — only needed in ECS, not in the Lambda
+    from dlt.sources.rest_api import rest_api_source  # lazy — only needed in ECS
+
     # Filter to GET-only collection endpoints.  Non-collection GET endpoints
     # (is_collection=False) are detail/lookup endpoints that require a known ID;
     # trying to bulk-fetch them always results in a 404 or empty payload.

--- a/lambdas/ingestion_agent/agents/ingestion_agent/spec_parser.py
+++ b/lambdas/ingestion_agent/agents/ingestion_agent/spec_parser.py
@@ -33,8 +33,12 @@ def extract_swagger_spec_url(html: str, page_url: str) -> str | None:
     """
     # Ordered from most specific (lowest false-positive risk) to most general.
     patterns = [
-        # SwaggerUIBundle({ url: "..." }) — canonical Swagger UI / Springdoc pattern
-        r'Swagger\w*(?:Bundle|UI)\s*\(\s*\{[^)]*?["\s,]url\s*:\s*["\']([^"\']+)["\']',
+        # SwaggerUIBundle({ url: "..." }) — canonical Swagger UI / Springdoc pattern.
+        # Uses [\s\S]*? (any char, non-greedy) instead of [^)]*? so it can skip over
+        # closing parens that appear before the url property, e.g.:
+        #   plugins: [SwaggerUIBundle.plugins.DownloadUrl],   ← ) before url
+        #   url: "/v3/api-docs"
+        r'Swagger\w*(?:Bundle|UI)\s*\(\s*\{[\s\S]*?["\s,]url\s*:\s*["\']([^"\']+)["\']',
         # data-spec-url HTML attribute (some custom wrappers)
         r'data-spec-url\s*=\s*["\']([^"\']+)["\']',
         # Redoc: <redoc spec-url="...">

--- a/lambdas/ingestion_agent/main.py
+++ b/lambdas/ingestion_agent/main.py
@@ -210,6 +210,12 @@ class RunRequest(BaseModel):
     )
 
 
+class DiscoverRequest(BaseModel):
+    """Request to discover an OpenAPI spec URL from a free-text API name."""
+
+    query: str = Field(..., description="Free-text API name or description (e.g. 'Stripe', 'PokeAPI')")
+
+
 # =============================================================================
 # Endpoints
 # =============================================================================
@@ -218,6 +224,31 @@ class RunRequest(BaseModel):
 @app.get("/")
 def health_check():
     return {"status": "healthy", "service": "ingestion_agent"}
+
+
+@app.post("/agent/ingestion/discover")
+async def discover_openapi(request: DiscoverRequest):
+    """
+    Discover an OpenAPI/Swagger spec URL from a free-text API name.
+
+    Searches DuckDuckGo, probes common spec paths, validates the result,
+    and returns the best single URL — or ``found: false`` if nothing is found.
+    """
+    from agents.ingestion_agent.discovery import discover_openapi_url
+
+    query = request.query.strip()
+    if not query:
+        raise HTTPException(status_code=400, detail="query must not be empty")
+
+    try:
+        result = await discover_openapi_url(query)
+    except Exception as exc:
+        logger.exception("OpenAPI discovery failed for query: %s", query)
+        return {"found": False, "url": "", "title": "", "error": str(exc)}
+
+    if result:
+        return {"found": True, "url": result["url"], "title": result["title"]}
+    return {"found": False, "url": "", "title": ""}
 
 
 def _build_oauth2_config(oauth2: OAuth2Credentials | None):

--- a/lambdas/ingestion_agent/requirements.txt
+++ b/lambdas/ingestion_agent/requirements.txt
@@ -3,7 +3,7 @@ fastapi==0.114.0
 mangum==0.19.0
 
 # AI agents
-pydantic-ai>=0.2.0
+pydantic-ai-slim[bedrock]>=0.7.0
 strands-agents>=1.25.0
 
 # Core

--- a/lambdas/ingestion_agent/requirements.txt
+++ b/lambdas/ingestion_agent/requirements.txt
@@ -13,8 +13,5 @@ boto3>=1.35.0
 # HTTP client
 httpx>=0.27.0
 
-# OpenAPI URL discovery (web search)
-ddgs>=0.5.0
-
 # YAML support
 pyyaml>=6.0.2

--- a/lambdas/ingestion_agent/requirements.txt
+++ b/lambdas/ingestion_agent/requirements.txt
@@ -18,6 +18,3 @@ ddgs>=0.5.0
 
 # YAML support
 pyyaml>=6.0.2
-
-# dlt for ingestion pipeline execution
-dlt[rest_api]>=1.0.0

--- a/lambdas/ingestion_agent/requirements.txt
+++ b/lambdas/ingestion_agent/requirements.txt
@@ -13,6 +13,9 @@ boto3>=1.35.0
 # HTTP client
 httpx>=0.27.0
 
+# OpenAPI URL discovery (web search)
+duckduckgo-search>=6.0.0
+
 # YAML support
 pyyaml>=6.0.2
 

--- a/lambdas/ingestion_agent/requirements.txt
+++ b/lambdas/ingestion_agent/requirements.txt
@@ -14,7 +14,7 @@ boto3>=1.35.0
 httpx>=0.27.0
 
 # OpenAPI URL discovery (web search)
-duckduckgo-search>=6.0.0
+ddgs>=0.5.0
 
 # YAML support
 pyyaml>=6.0.2

--- a/lambdas/ingestion_plans/.dockerignore
+++ b/lambdas/ingestion_plans/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/query_api/.dockerignore
+++ b/lambdas/query_api/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/serverless_analytics/.dockerignore
+++ b/lambdas/serverless_analytics/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/serverless_processing/.dockerignore
+++ b/lambdas/serverless_processing/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/serverless_processing_iceberg/.dockerignore
+++ b/lambdas/serverless_processing_iceberg/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/serverless_xtable/.dockerignore
+++ b/lambdas/serverless_xtable/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/transform_jobs/.dockerignore
+++ b/lambdas/transform_jobs/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/transformation_agent/.dockerignore
+++ b/lambdas/transformation_agent/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.ruff_cache
+.mypy_cache
+*.egg-info
+tests/
+test_*.py
+conftest.py
+*.md

--- a/lambdas/transformation_agent/requirements.txt
+++ b/lambdas/transformation_agent/requirements.txt
@@ -3,7 +3,7 @@ fastapi==0.114.0
 mangum==0.19.0
 
 # AI agents
-pydantic-ai>=0.2.0
+pydantic-ai-slim[bedrock]>=0.7.0
 
 # Core
 pydantic>=2.9.0
@@ -11,9 +11,6 @@ boto3>=1.35.0
 
 # HTTP client
 httpx>=0.27.0
-
-# Retry / backoff
-backoff>=2.2.1
 
 # YAML support
 pyyaml>=6.0.2

--- a/stack/constructs/api_service.py
+++ b/stack/constructs/api_service.py
@@ -411,12 +411,14 @@ class ApiService(Construct):
         )
 
     def _grant_bedrock_permissions(self) -> None:
-        """Grant access to invoke Bedrock foundation models"""
+        """Grant access to invoke Bedrock foundation models and system tools."""
         self.lambda_function.add_to_role_policy(
             iam.PolicyStatement(
                 actions=[
                     "bedrock:InvokeModel",
                     "bedrock:InvokeModelWithResponseStream",
+                    # Required for Nova Web Grounding (nova_grounding system tool)
+                    "bedrock:InvokeTool",
                 ],
                 resources=["*"],
             )

--- a/stack/serverless_data_lake_stack.py
+++ b/stack/serverless_data_lake_stack.py
@@ -879,14 +879,44 @@ class ServerlessDataLakeStack(Stack):
             ),
         )
 
-        # Container — build context is project root so we can COPY agents/ from the Lambda source
+        # Container — build context is project root so we can COPY agents/ from the Lambda source.
+        # The exclude list is comprehensive to minimize cdk.out staging area size.
         ingestion_container = task_definition.add_container(
             "ingestion-runner",
             image=ecs.ContainerImage.from_asset(
                 ".",
                 file="containers/ingestion_runner/Dockerfile",
                 platform=ecr_assets.Platform.LINUX_AMD64,
-                exclude=["cdk.out", ".git", "node_modules", "frontend/node_modules", "frontend/dist"],
+                exclude=[
+                    # Version control / build output
+                    "cdk.out", ".git",
+                    # JS ecosystem
+                    "node_modules", "frontend",
+                    # Other containers / services
+                    "metabase", "containers/dbt_runner",
+                    # CDK / Python tooling
+                    "stack", "layers", ".venv",
+                    "__pycache__", "*.pyc", "*.egg-info",
+                    ".pytest_cache", ".ruff_cache", ".mypy_cache",
+                    # Docs / scripts / misc
+                    "docs", "examples", "assets", "scripts",
+                    "tests", "README.md", "CLAUDE.md", "SECURITY_PLAN.md",
+                    "requirements*.txt", "source.bat", "teste.py",
+                    # Lambdas not needed by the runner (keep only ingestion_agent/)
+                    "lambdas/auth",
+                    "lambdas/authorizer",
+                    "lambdas/chat_api",
+                    "lambdas/endpoints",
+                    "lambdas/ingestion_plans",
+                    "lambdas/query_api",
+                    "lambdas/serverless_analytics",
+                    "lambdas/serverless_ingestion",
+                    "lambdas/serverless_processing",
+                    "lambdas/serverless_processing_iceberg",
+                    "lambdas/serverless_xtable",
+                    "lambdas/transform_jobs",
+                    "lambdas/transformation_agent",
+                ],
             ),
             logging=ecs.LogDrivers.aws_logs(
                 stream_prefix="ingestion-runner",

--- a/tests/test_ingestion_agent.py
+++ b/tests/test_ingestion_agent.py
@@ -1015,6 +1015,23 @@ class TestExtractSwaggerSpecUrl:
         result = extract_swagger_spec_url(html, "https://api.projurisadv.com.br/ui/index.html")
         assert result == "https://api.projurisadv.com.br/v3/api-docs"
 
+    def test_url_after_property_with_parens(self):
+        """url: comes AFTER a property whose value contains ')' — the old [^)]* regex failed here."""
+        html = """
+        <script>
+        window.onload = function() {
+          window.ui = SwaggerUIBundle({
+            plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+            presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+            url: "/v3/api-docs",
+            dom_id: '#swagger-ui',
+          })
+        }
+        </script>
+        """
+        result = extract_swagger_spec_url(html, "https://api.projurisadv.com.br/ui/index.html")
+        assert result == "https://api.projurisadv.com.br/v3/api-docs"
+
 
 class TestEndpointSpecFieldDescriptions:
     """Tests that EndpointSpec properly handles field_descriptions."""


### PR DESCRIPTION
## Summary

This PR adds intelligent OpenAPI/Swagger spec URL discovery to the ingestion pipeline, allowing users to find API specs by name rather than manually entering URLs. The discovery uses Amazon Nova's web grounding capability (no external API keys or rate limits) and includes robust fallback mechanisms for legacy Swagger UIs.

## Key Changes

### Backend
- **New discovery module** (`lambdas/ingestion_agent/agents/ingestion_agent/discovery.py`):
  - Uses Amazon Nova 2 Lite with `nova_grounding` system tool to search the web for OpenAPI specs
  - Probes candidate URLs against a comprehensive list of common spec paths
  - Validates discovered specs and API index roots
  - Returns both direct spec URLs and fallback candidate hosts

- **Enhanced spec fetching** (`lambdas/ingestion_agent/agents/ingestion_agent/agent.py`):
  - Added `_probe_spec_url()` helper for non-recursive spec validation
  - Implemented fallback probing for legacy/dynamic Swagger pages (e.g., Springfox, old swagger-ui-dist) that compute spec URLs via JavaScript
  - Probes well-known paths on the same host when HTML parsing can't extract a literal spec URL
  - Added validation to reject APIs with no ingestible endpoints (utility/processing APIs)

- **New API endpoint** (`lambdas/ingestion_agent/main.py`):
  - `POST /agent/ingestion/discover` accepts a free-text API name and returns discovered spec URL and title

- **Improved spec URL extraction** (`lambdas/ingestion_agent/agents/ingestion_agent/spec_parser.py`):
  - Fixed regex pattern to handle properties with parentheses before the `url:` field
  - Added test case for Springdoc pattern with complex property values

### Frontend
- **URL discovery UI** (`frontend/src/components/ai/AiPipeline.jsx`):
  - Added toggle between "Find API" (search mode) and "Enter URL" (manual mode)
  - Search mode with autocomplete-style input and magic wand button
  - Displays discovered API name and URL with option to change
  - Graceful fallback to manual entry on discovery failure
  - Integrated with new backend discovery endpoint

- **API client** (`frontend/src/api/dataLakeClient.js`):
  - Added `discover()` method to call the new discovery endpoint

### Infrastructure & Optimization
- Added `.dockerignore` files across all Lambda functions and containers to minimize Docker build context
- Optimized CDK exclude list in `serverless_data_lake_stack.py` to reduce staging area size
- Updated dependencies: `pydantic-ai>=0.2.0` → `pydantic-ai-slim[bedrock]>=0.7.0` for Bedrock support
- Removed unused `dlt[rest_api]` dependency from ingestion_agent (kept base `dlt` in runner)

## Notable Implementation Details

- **No external API keys**: Uses AWS Bedrock's native Nova grounding instead of DuckDuckGo or other external search APIs
- **Comprehensive fallback strategy**: When direct spec URL fails, probes both host root and page directory for common spec paths
- **Validation-first**: Probes verify responses are valid OpenAPI specs or API index roots before returning
- **User-friendly errors**: Clear messaging when specs can't be found, with guidance to switch to manual entry
- **Endpoint filtering**: Rejects APIs with no GET collection endpoints, preventing ingestion of utility/processing APIs

https://claude.ai/code/session_01V4ZinMp79eBnv5V5Uq8EJC