### PR TITLE
Implement origin-based CORS and switch to session storage

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -16,7 +16,7 @@ const queryClient = new QueryClient({
 });
 
 function ProtectedRoute({ children }) {
-  return !!localStorage.getItem('dataLakeApiKey')
+  return !!sessionStorage.getItem('dataLakeApiKey')
     ? children
     : <Navigate to="/login" replace />;
 }
@@ -25,7 +25,7 @@ function AppRoutes() {
   const navigate = useNavigate();
 
   const handleLogout = () => {
-    localStorage.removeItem('dataLakeApiKey');
+    sessionStorage.removeItem('dataLakeApiKey');
     navigate('/');
   };
 

--- a/frontend/src/api/dataLakeClient.js
+++ b/frontend/src/api/dataLakeClient.js
@@ -14,7 +14,7 @@ class DataLakeClient {
 
   async request(endpoint, options = {}) {
     const url = `${this.baseUrl}${endpoint}`;
-    const apiKey = localStorage.getItem('dataLakeApiKey');
+    const apiKey = sessionStorage.getItem('dataLakeApiKey');
 
     const config = {
       headers: {
@@ -34,7 +34,7 @@ class DataLakeClient {
     if (!response.ok) {
       // Token expired or revoked — clear session and force re-login
       if (response.status === 401 || response.status === 403) {
-        localStorage.removeItem('dataLakeApiKey');
+        sessionStorage.removeItem('dataLakeApiKey');
         window.location.reload();
         return;
       }

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -35,7 +35,7 @@ export default function LoginPage({ onLogin }) {
         return;
       }
 
-      localStorage.setItem('dataLakeApiKey', data.token);
+      sessionStorage.setItem('dataLakeApiKey', data.token);
       onLogin();
     } catch {
       setError('Connection error. Check if the API is reachable.');

--- a/lambdas/auth/main.py
+++ b/lambdas/auth/main.py
@@ -21,6 +21,13 @@ import json
 import logging
 import os
 
+_ALLOWED_ORIGINS = set(
+    os.environ.get(
+        "ALLOWED_ORIGINS",
+        "https://tadpoledata.com,https://www.tadpoledata.com,http://localhost:5173",
+    ).split(",")
+)
+
 import boto3
 from botocore.exceptions import ClientError
 
@@ -34,19 +41,21 @@ _cached_credentials: dict | None = None
 _cached_api_key: str | None = None
 
 
-def _cors_headers() -> dict:
+def _cors_headers(origin: str) -> dict:
+    allowed_origin = origin if origin in _ALLOWED_ORIGINS else "https://tadpoledata.com"
     return {
-        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Origin": allowed_origin,
         "Access-Control-Allow-Headers": "content-type,x-api-key",
         "Access-Control-Allow-Methods": "POST,OPTIONS",
         "Content-Type": "application/json",
+        "Vary": "Origin",
     }
 
 
-def _response(status_code: int, body: dict) -> dict:
+def _response(status_code: int, body: dict, origin: str = "") -> dict:
     return {
         "statusCode": status_code,
-        "headers": _cors_headers(),
+        "headers": _cors_headers(origin),
         "body": json.dumps(body),
     }
 
@@ -89,45 +98,47 @@ def handler(event: dict, context) -> dict:
     method = (
         event.get("requestContext", {}).get("http", {}).get("method", "").upper()
     )
+    headers = event.get("headers") or {}
+    origin = headers.get("origin") or headers.get("Origin") or ""
 
     # CORS preflight
     if method == "OPTIONS":
-        return _response(200, {})
+        return _response(200, {}, origin)
 
     if method != "POST":
-        return _response(405, {"detail": "Method not allowed"})
+        return _response(405, {"detail": "Method not allowed"}, origin)
 
     # Parse body
     try:
         body = json.loads(event.get("body") or "{}")
     except (json.JSONDecodeError, TypeError):
-        return _response(400, {"detail": "Invalid JSON"})
+        return _response(400, {"detail": "Invalid JSON"}, origin)
 
     email: str = body.get("email", "").strip()
     password: str = body.get("password", "")
 
     if not email or not password:
-        return _response(400, {"detail": "Email and password are required"})
+        return _response(400, {"detail": "Email and password are required"}, origin)
 
     # Load credentials
     credentials = _get_credentials()
     if not credentials or credentials.get("password_hash") == "placeholder":
         logger.warning("Auth credentials not yet configured — run: python scripts/hash_password.py")
-        return _response(503, {"detail": "Auth not configured. Run scripts/hash_password.py"})
+        return _response(503, {"detail": "Auth not configured. Run scripts/hash_password.py"}, origin)
 
     # Constant-time email comparison (avoids timing attacks)
     stored_email = credentials.get("email", "")
     if not hmac.compare_digest(stored_email.lower(), email.lower()):
-        return _response(401, {"detail": "Invalid email or password"})
+        return _response(401, {"detail": "Invalid email or password"}, origin)
 
     if not _verify_password(password, credentials["password_hash"], credentials["salt"]):
-        return _response(401, {"detail": "Invalid email or password"})
+        return _response(401, {"detail": "Invalid email or password"}, origin)
 
     try:
         api_key = _get_api_key()
     except ClientError as e:
         logger.error(f"Failed to read API key: {e}")
-        return _response(500, {"detail": "Internal server error"})
+        return _response(500, {"detail": "Internal server error"}, origin)
 
     logger.info(f"Successful login: {email}")
-    return _response(200, {"token": api_key})
+    return _response(200, {"token": api_key}, origin)

--- a/lambdas/query_api/main.py
+++ b/lambdas/query_api/main.py
@@ -102,9 +102,9 @@ os.makedirs(EXTENSION_DIR, exist_ok=True)
 
 registry = SchemaRegistry()
 
-logger.info(f"AWS_ACCOUNT_ID: {AWS_ACCOUNT_ID}")
-logger.info(f"AWS_REGION: {AWS_REGION}")
-logger.info(f"CATALOG_NAME: {CATALOG_NAME}")
+logger.debug(f"AWS_ACCOUNT_ID: {AWS_ACCOUNT_ID}")
+logger.debug(f"AWS_REGION: {AWS_REGION}")
+logger.debug(f"CATALOG_NAME: {CATALOG_NAME}")
 
 
 def configure_duckdb():
@@ -139,7 +139,7 @@ def configure_duckdb():
                 AUTHORIZATION_TYPE 'sigv4'
             );
         """
-        logger.info(f"Attaching catalog with: {attach_sql}")
+        logger.debug("Attaching Glue Iceberg catalog")
         con.execute(attach_sql)
         logger.info("Catalog attached successfully")
 

--- a/stack/constructs/api_gateway.py
+++ b/stack/constructs/api_gateway.py
@@ -90,7 +90,7 @@ class ApiGateway(Construct):
             cors_preflight=apigwv2.CorsPreflightOptions(
                 allow_origins=cors_origins,
                 allow_methods=cors_methods,
-                allow_headers=["*"],
+                allow_headers=["content-type", "x-api-key"],
             ),
         )
 


### PR DESCRIPTION
## Summary
This PR enhances security by implementing origin-based CORS validation instead of allowing all origins, and switches from persistent localStorage to sessionStorage for API tokens. These changes reduce the attack surface and improve session security.

## Key Changes

**CORS Security Improvements (Auth Lambda)**
- Replace wildcard CORS origin (`*`) with origin validation against an allowlist
- Add configurable `ALLOWED_ORIGINS` environment variable with sensible defaults (tadpoledata.com and localhost:5173)
- Validate incoming `Origin` header and only return it if whitelisted; fallback to tadpoledata.com otherwise
- Add `Vary: Origin` header to ensure proper caching behavior
- Update API Gateway CORS configuration to explicitly allow only required headers (`content-type`, `x-api-key`) instead of wildcard

**Session Storage Migration (Frontend)**
- Replace `localStorage` with `sessionStorage` for storing API tokens across all frontend modules
- Tokens are now cleared when the browser tab/window closes, improving security for shared devices
- Affects: App.jsx, LoginPage.jsx, and dataLakeClient.js

**Logging Improvements (Query API)**
- Downgrade non-critical initialization logs from `info` to `debug` level
- Simplify catalog attachment log message to reduce noise

## Implementation Details
- The auth lambda now extracts the `Origin` header (case-insensitive) from incoming requests and passes it through the response chain
- Allowlist defaults to: `https://tadpoledata.com`, `https://www.tadpoledata.com`, `http://localhost:5173`
- All response paths in the auth handler now include origin parameter for consistent CORS header handling

https://claude.ai/code/session_016qfBu7v1XiMwQvvXDRPAaK